### PR TITLE
Gtk css

### DIFF
--- a/data/client/king_phisher/style/theme.css
+++ b/data/client/king_phisher/style/theme.css
@@ -151,6 +151,7 @@ GtkEntry:insensitive {
 	background-color: alpha(gray, 0.8);
 	background-image: none;
 	color: white;
+	
 }
 
 GtkFileChooser .search-bar {
@@ -318,6 +319,19 @@ GtkRadioButton {
 	background-image: none;
 	border-radius: 5px 5px 5px 5px;
 }
+
+GtkFrame {
+	background: none;
+}
+
+GtkGrid {
+	background: none;
+}
+
+GtkEntry: {
+	color: white;
+}
+
 
 /***********************************************************
  * Extra classes

--- a/data/client/king_phisher/style/theme.css
+++ b/data/client/king_phisher/style/theme.css
@@ -151,7 +151,6 @@ GtkEntry:insensitive {
 	background-color: alpha(gray, 0.8);
 	background-image: none;
 	color: white;
-	
 }
 
 GtkFileChooser .search-bar {
@@ -321,17 +320,12 @@ GtkRadioButton {
 }
 
 GtkFrame {
-	background: none;
+	background:none;
 }
 
 GtkGrid {
-	background: none;
+	background:none;
 }
-
-GtkEntry: {
-	color: white;
-}
-
 
 /***********************************************************
  * Extra classes


### PR DESCRIPTION
Added GtkFrame and GtkGrid background: none to css to correct the issue in ubuntu where grey boxes where being displayed in New or Edit Campaign, Company. 

to test use Ubuntu Unity or Ubuntu flashback gnome3 malecity. launch king phisher client with changes in theme, and either edit campaign or create a new. On the Company Tab Click on Existing, New, and None and verify no Grey boxes are showing up in the frames for Existing Company and New Company.

Please note that when New Company is insensitive that the default preloaded text will not show as white as it is not considered Text. To test that the GtkEntry and GtkCombobox are displaying white text when insensitive you will need to put text in those fields under Company > New, then change to Existing or None for it to be insensitive.

@zeroSteiner 