### PR TITLE
Added additonal filtering to the campaign selection diaglog

### DIFF
--- a/data/king-phisher.ipynb
+++ b/data/king-phisher.ipynb
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "collapsed": false
    },
@@ -48,6 +48,7 @@
     "import yaml\n",
     "\n",
     "king_phisher_home = widgets.Text(value='/opt/king-phisher', width='350px')\n",
+    "king_phisher_server_config = widgets.Text(value='server_config.yml', width='350px')\n",
     "db_connection = widgets.Text(placeholder='optional', width='350px')\n",
     "setup_button = widgets.Button(description='Setup', width='550px')\n",
     "results = widgets.HTML()\n",
@@ -69,13 +70,14 @@
     "    if db_connection.value:\n",
     "        db_manager.init_database(db_connection.value)\n",
     "    else:\n",
-    "        with open(os.path.join(directory, 'server-config.yml'), 'r') as file_h:\n",
+    "        with open(os.path.join(directory, king_phisher_server_config.value), 'r') as file_h:\n",
     "            server_config = yaml.load(file_h)\n",
     "        db_manager.init_database(server_config['server']['database'])\n",
     "    results.value = 'Successfully Initialized The Database'\n",
     "\n",
     "setup_button.on_click(setup_and_initialize)\n",
     "display.display(widgets.HBox([widgets.HTML(value='Install Directory', width='200px'), king_phisher_home]))\n",
+    "display.display(widgets.HBox([widgets.HTML(value='Server Configuration File', width='200px'), king_phisher_server_config]))\n",
     "display.display(widgets.HBox([widgets.HTML(value='Database Connection String', width='200px'), db_connection]))\n",
     "display.display(setup_button)\n",
     "display.display(results)"
@@ -181,6 +183,15 @@
     "session.commit()\n",
     "session.close()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Added gtk.menubutton with gtk.chkmenuitem for additional campaign filtering options. Removed gtk check box to filter expired campaigns, updated information about number of campaigns loaded into tree

* [x] Pass all unit testing
* [x] Pass King-phishers pylint rcfile
* [x] Able to filter out expired campaigns
* [x] Able to filter out current user campaigns
* [x] Able to filter out other users campaigns
* [x] Stores users filter setting on exit

@zeroSteiner 