### PR TITLE
GtkTreeView .entry change

### DIFF
--- a/data/client/king_phisher/style/theme.css
+++ b/data/client/king_phisher/style/theme.css
@@ -325,6 +325,10 @@ GtkTreeView {
   color: @theme_color_tv_fg;
 }
 
+GtkTreeView .entry {
+  padding: 0px;
+}
+  
 GtkTreeView row:hover,
 GtkTreeView row:selected {
   background-color: @theme_color_tv_hobg;


### PR DESCRIPTION
@zeroSteiner Made the padding changing to GtkTreeView .entry in theme.css to create a clean view when editing fields in tags.

- [x] When running king-phisher client in Fedora, padding is no longer presence on Gtk.TreeView where items can be edited such as the Tags dialog.
- [x] No undesired effects or changes to the rest of the king-phisher interface.
- [x] Formatting is correct for the css file.