### PR TITLE
Validate SSH Host Keys

### DIFF
--- a/data/client/king_phisher/king-phisher-client.ui
+++ b/data/client/king_phisher/king-phisher-client.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.19.0 
+<!-- Generated with glade 3.19.0
 
 Copyright (c) 2013-2015, SecureState LLC
 All rights reserved.
@@ -112,6 +112,189 @@ Brandan Geise</property>
         </child>
       </object>
     </child>
+  </object>
+  <object class="GtkDialog" id="CampaignSelectionDialog">
+    <property name="width_request">650</property>
+    <property name="height_request">350</property>
+    <property name="can_focus">False</property>
+    <property name="border_width">5</property>
+    <property name="title" translatable="yes">King Phisher Campaigns</property>
+    <property name="type_hint">dialog</property>
+    <child internal-child="vbox">
+      <object class="GtkBox" id="CampaignSelectionDialog.dialog-vbox4">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">5</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="CampaignSelectionDialog.dialog-action_area4">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="CampaignSelectionDialog.button_cancel">
+                <property name="label" translatable="yes">Cancel</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="CampaignSelectionDialog.button_select">
+                <property name="label" translatable="yes">Select</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack_type">end</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="box22">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="spacing">5</property>
+            <child>
+              <object class="GtkLabel" id="CampaignSelectionDialog.label_campaign_info">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">start</property>
+                <property name="label" translatable="yes">Showing 0 of 0 Campaigns</property>
+                <attributes>
+                  <attribute name="scale" value="1.25"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label51">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Expired Campaigns</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="pack_type">end</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkDrawingArea" id="CampaignSelectionDialog.drawingarea_color_key">
+                <property name="width_request">20</property>
+                <property name="height_request">20</property>
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">center</property>
+                <property name="valign">center</property>
+                <signal name="draw" handler="signal_drawingarea_draw" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="pack_type">end</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkScrolledWindow" id="CampaignSelectionDialog.scrolledwindow5">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <child>
+              <object class="GtkTreeView" id="CampaignSelectionDialog.treeview_campaigns">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <signal name="row-activated" handler="signal_treeview_row_activated" swapped="no"/>
+                <child internal-child="selection">
+                  <object class="GtkTreeSelection" id="treeview-selection4"/>
+                </child>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="CampaignSelectionDialog.box1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="spacing">10</property>
+            <child>
+              <object class="GtkMenuButton" id="CampaignSelectionDialog.menubutton_filter">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="tooltip_text" translatable="yes">Filtering options for found campaigns.</property>
+                <property name="direction">right</property>
+                <child>
+                  <placeholder/>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="CampaignSelectionDialog.button_new_campaign">
+                <property name="label" translatable="yes">New Campaign</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="tooltip_text" translatable="yes">Create a new campaign.</property>
+                <signal name="clicked" handler="signal_button_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="pack_type">end</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="-6">CampaignSelectionDialog.button_cancel</action-widget>
+      <action-widget response="-10">CampaignSelectionDialog.button_select</action-widget>
+    </action-widgets>
   </object>
   <object class="GtkBox" id="CampaignViewCredentialsTab">
     <property name="width_request">400</property>
@@ -1639,6 +1822,180 @@ Brandan Geise</property>
       <action-widget response="-5">button1</action-widget>
     </action-widgets>
   </object>
+  <object class="GtkDialog" id="HostKeyWarnDialog">
+    <property name="width_request">450</property>
+    <property name="height_request">250</property>
+    <property name="can_focus">False</property>
+    <property name="resizable">False</property>
+    <property name="default_width">450</property>
+    <property name="default_height">-1</property>
+    <property name="destroy_with_parent">True</property>
+    <property name="type_hint">dialog</property>
+    <child internal-child="vbox">
+      <object class="GtkBox" id="dialog-vbox15">
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">3</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="dialog-action_area15">
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="HostKeyWarnDialog.button_accept">
+                <property name="label" translatable="yes">Accept</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="image">StockStopImage</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="HostKeyWarnDialog.button_reject">
+                <property name="label" translatable="yes">Reject</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="image">StockApplyImage</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="box27">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">5</property>
+            <child>
+              <object class="GtkBox" id="box28">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">center</property>
+                <property name="spacing">5</property>
+                <child>
+                  <object class="GtkImage" id="image3">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="stock">gtk-dialog-warning</property>
+                    <property name="icon_size">6</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label64">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Invalid Host Key!</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="scale" value="1.5"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label65">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">This host key was previously intstored and has changed. It is
+possible that someone is intercepting your communications.
+It is also possible that the host key has changed. Please
+contact your system administrator.</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFrame" id="frame3">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="vexpand">True</property>
+                <property name="label_xalign">0</property>
+                <property name="shadow_type">none</property>
+                <child>
+                  <object class="GtkAlignment" id="alignment7">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="left_padding">12</property>
+                    <child>
+                      <object class="GtkScrolledWindow" id="scrolledwindow4">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="shadow_type">in</property>
+                        <child>
+                          <object class="GtkTextView" id="HostKeyWarnDialog.textview_key_details">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="editable">False</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child type="label">
+                  <object class="GtkLabel" id="label66">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Host Key Details</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="-3">HostKeyWarnDialog.button_reject</action-widget>
+      <action-widget response="-2">HostKeyWarnDialog.button_accept</action-widget>
+    </action-widgets>
+  </object>
   <object class="GtkBox" id="MailSenderEditTab">
     <property name="width_request">400</property>
     <property name="height_request">300</property>
@@ -3145,189 +3502,10 @@ Brandan Geise</property>
     <property name="can_focus">False</property>
     <property name="stock">gtk-add</property>
   </object>
-  <object class="GtkDialog" id="CampaignSelectionDialog">
-    <property name="width_request">650</property>
-    <property name="height_request">350</property>
+  <object class="GtkImage" id="StockApplyImage">
+    <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="border_width">5</property>
-    <property name="title" translatable="yes">King Phisher Campaigns</property>
-    <property name="type_hint">dialog</property>
-    <child internal-child="vbox">
-      <object class="GtkBox" id="CampaignSelectionDialog.dialog-vbox4">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="orientation">vertical</property>
-        <property name="spacing">5</property>
-        <child internal-child="action_area">
-          <object class="GtkButtonBox" id="CampaignSelectionDialog.dialog-action_area4">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
-            <child>
-              <object class="GtkButton" id="CampaignSelectionDialog.button_cancel">
-                <property name="label" translatable="yes">Cancel</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="CampaignSelectionDialog.button_select">
-                <property name="label" translatable="yes">Select</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="pack_type">end</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkBox" id="box22">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="spacing">5</property>
-            <child>
-              <object class="GtkLabel" id="CampaignSelectionDialog.label_campaign_info">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="label" translatable="yes">Showing 0 of 0 Campaigns</property>
-                <attributes>
-                  <attribute name="scale" value="1.25"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="label51">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Expired Campaigns</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="pack_type">end</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkDrawingArea" id="CampaignSelectionDialog.drawingarea_color_key">
-                <property name="width_request">20</property>
-                <property name="height_request">20</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">center</property>
-                <property name="valign">center</property>
-                <signal name="draw" handler="signal_drawingarea_draw" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="pack_type">end</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkScrolledWindow" id="CampaignSelectionDialog.scrolledwindow5">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <child>
-              <object class="GtkTreeView" id="CampaignSelectionDialog.treeview_campaigns">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <signal name="row-activated" handler="signal_treeview_row_activated" swapped="no"/>
-                <child internal-child="selection">
-                  <object class="GtkTreeSelection" id="treeview-selection4"/>
-                </child>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkBox" id="CampaignSelectionDialog.box1">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="spacing">10</property>
-            <child>
-              <object class="GtkMenuButton" id="CampaignSelectionDialog.menubutton_filter">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="tooltip_text" translatable="yes">Filtering options for found campaigns.</property>
-                <property name="direction">right</property>
-                <child>
-                  <placeholder/>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="CampaignSelectionDialog.button_new_campaign">
-                <property name="label" translatable="yes">New Campaign</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="tooltip_text" translatable="yes">Create a new campaign.</property>
-                <property name="image">StockAddImage</property>
-                <signal name="clicked" handler="signal_button_clicked" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="pack_type">end</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">2</property>
-          </packing>
-        </child>
-      </object>
-    </child>
-    <action-widgets>
-      <action-widget response="-6">CampaignSelectionDialog.button_cancel</action-widget>
-      <action-widget response="-10">CampaignSelectionDialog.button_select</action-widget>
-    </action-widgets>
+    <property name="stock">gtk-apply</property>
   </object>
   <object class="GtkImage" id="StockDeleteImage">
     <property name="visible">True</property>
@@ -3343,6 +3521,216 @@ Brandan Geise</property>
     <property name="visible">True</property>
     <property name="can_focus">False</property>
     <property name="stock">gtk-execute</property>
+  </object>
+  <object class="GtkDialog" id="ClonePageDialog">
+    <property name="width_request">600</property>
+    <property name="height_request">400</property>
+    <property name="can_focus">False</property>
+    <property name="title" translatable="yes">King Phisher</property>
+    <property name="default_width">600</property>
+    <property name="default_height">400</property>
+    <property name="destroy_with_parent">True</property>
+    <property name="type_hint">dialog</property>
+    <child internal-child="vbox">
+      <object class="GtkBox" id="dialog-vbox6">
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="dialog-action_area6">
+            <property name="can_focus">False</property>
+            <property name="margin_right">3</property>
+            <property name="margin_bottom">3</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="ClonePageDialog.button_cancel">
+                <property name="label" translatable="yes">Done</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="ClonePageDialog.button_clone">
+                <property name="label" translatable="yes">Clone</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="image">StockExecuteImage</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="pack_type">end</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="box7">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="margin_left">3</property>
+            <property name="margin_right">3</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">3</property>
+            <child>
+              <object class="GtkGrid" id="grid7">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="row_spacing">3</property>
+                <property name="column_spacing">5</property>
+                <child>
+                  <object class="GtkEntry" id="ClonePageDialog.entry_target">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="tooltip_text" translatable="yes">The URL of the target web page to clone.</property>
+                    <property name="placeholder_text" translatable="yes">http://targetsite/targetpage</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">0</property>
+                    <property name="width">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label20">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Directory</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkEntry" id="ClonePageDialog.entry_clone_directory">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="tooltip_text" translatable="yes">The directory to save the cloned page to.</property>
+                    <property name="hexpand">True</property>
+                    <property name="editable">False</property>
+                    <property name="primary_icon_stock">gtk-directory</property>
+                    <property name="placeholder_text" translatable="yes">/path/to/clone/to</property>
+                    <signal name="activate" handler="signal_multi_set_directory" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label19">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Target URL</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="ClonePageDialog.button_set_directory">
+                    <property name="label" translatable="yes">Select</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <signal name="clicked" handler="signal_multi_set_directory" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="left_attach">2</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkScrolledWindow" id="scrolledwindow1">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="shadow_type">in</property>
+                <child>
+                  <object class="GtkTreeView" id="ClonePageDialog.treeview_resources">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <child internal-child="selection">
+                      <object class="GtkTreeSelection" id="treeview-selection8"/>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="box8">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="spacing">5</property>
+                <child>
+                  <object class="GtkLabel" id="ClonePageDialog.label_status">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">Status: Waiting</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSpinner" id="ClonePageDialog.spinner_status">
+                    <property name="can_focus">False</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="-6">ClonePageDialog.button_cancel</action-widget>
+      <action-widget response="-10">ClonePageDialog.button_clone</action-widget>
+    </action-widgets>
   </object>
   <object class="GtkImage" id="StockHelpImage">
     <property name="visible">True</property>
@@ -3573,222 +3961,6 @@ Brandan Geise</property>
     <property name="can_focus">False</property>
     <property name="stock">gtk-properties</property>
   </object>
-  <object class="GtkImage" id="StockStopImage">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-stop</property>
-  </object>
-  <object class="GtkDialog" id="ClonePageDialog">
-    <property name="width_request">600</property>
-    <property name="height_request">400</property>
-    <property name="can_focus">False</property>
-    <property name="title" translatable="yes">King Phisher</property>
-    <property name="default_width">600</property>
-    <property name="default_height">400</property>
-    <property name="destroy_with_parent">True</property>
-    <property name="type_hint">dialog</property>
-    <child internal-child="vbox">
-      <object class="GtkBox" id="dialog-vbox6">
-        <property name="can_focus">False</property>
-        <property name="orientation">vertical</property>
-        <property name="spacing">2</property>
-        <child internal-child="action_area">
-          <object class="GtkButtonBox" id="dialog-action_area6">
-            <property name="can_focus">False</property>
-            <property name="margin_right">3</property>
-            <property name="margin_bottom">3</property>
-            <property name="layout_style">end</property>
-            <child>
-              <object class="GtkButton" id="ClonePageDialog.button_cancel">
-                <property name="label" translatable="yes">Done</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="image">StockStopImage</property>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="ClonePageDialog.button_clone">
-                <property name="label" translatable="yes">Clone</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="image">StockExecuteImage</property>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="pack_type">end</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkBox" id="box7">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="margin_left">3</property>
-            <property name="margin_right">3</property>
-            <property name="orientation">vertical</property>
-            <property name="spacing">3</property>
-            <child>
-              <object class="GtkGrid" id="grid7">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="row_spacing">3</property>
-                <property name="column_spacing">5</property>
-                <child>
-                  <object class="GtkEntry" id="ClonePageDialog.entry_target">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="tooltip_text" translatable="yes">The URL of the target web page to clone.</property>
-                    <property name="placeholder_text" translatable="yes">http://targetsite/targetpage</property>
-                  </object>
-                  <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">0</property>
-                    <property name="width">2</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="label20">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Directory</property>
-                  </object>
-                  <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkEntry" id="ClonePageDialog.entry_clone_directory">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="tooltip_text" translatable="yes">The directory to save the cloned page to.</property>
-                    <property name="hexpand">True</property>
-                    <property name="editable">False</property>
-                    <property name="primary_icon_stock">gtk-directory</property>
-                    <property name="placeholder_text" translatable="yes">/path/to/clone/to</property>
-                    <signal name="activate" handler="signal_multi_set_directory" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="label19">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Target URL</property>
-                  </object>
-                  <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkButton" id="ClonePageDialog.button_set_directory">
-                    <property name="label" translatable="yes">Select</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <signal name="clicked" handler="signal_multi_set_directory" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="left_attach">2</property>
-                    <property name="top_attach">1</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkScrolledWindow" id="scrolledwindow1">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="shadow_type">in</property>
-                <child>
-                  <object class="GtkTreeView" id="ClonePageDialog.treeview_resources">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <child internal-child="selection">
-                      <object class="GtkTreeSelection" id="treeview-selection8"/>
-                    </child>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkBox" id="box8">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="spacing">5</property>
-                <child>
-                  <object class="GtkLabel" id="ClonePageDialog.label_status">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="halign">end</property>
-                    <property name="label" translatable="yes">Status: Waiting</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkSpinner" id="ClonePageDialog.spinner_status">
-                    <property name="can_focus">False</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-      </object>
-    </child>
-    <action-widgets>
-      <action-widget response="-6">ClonePageDialog.button_cancel</action-widget>
-      <action-widget response="-10">ClonePageDialog.button_clone</action-widget>
-    </action-widgets>
-  </object>
   <object class="GtkMenuBar" id="MainMenuBar">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -4006,7 +4178,6 @@ Brandan Geise</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="accel_path">&lt;KingPhisherClient&gt;/Edit/Delete Campaign</property>
-                <property name="image">StockDeleteImage</property>
                 <property name="use_stock">False</property>
                 <signal name="activate" handler="do_edit_delete_campaign" swapped="no"/>
               </object>
@@ -4017,7 +4188,6 @@ Brandan Geise</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="accel_path">&lt;KingPhisherClient&gt;/Edit/Stop Service</property>
-                <property name="image">StockStopImage</property>
                 <property name="use_stock">False</property>
                 <signal name="activate" handler="do_edit_stop_service" swapped="no"/>
               </object>
@@ -4117,6 +4287,183 @@ Brandan Geise</property>
         </child>
       </object>
     </child>
+  </object>
+  <object class="GtkImage" id="StockStopImage">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-stop</property>
+  </object>
+  <object class="GtkDialog" id="HostKeyAcceptDialog">
+    <property name="width_request">450</property>
+    <property name="height_request">250</property>
+    <property name="can_focus">False</property>
+    <property name="resizable">False</property>
+    <property name="default_width">450</property>
+    <property name="destroy_with_parent">True</property>
+    <property name="type_hint">dialog</property>
+    <child internal-child="vbox">
+      <object class="GtkBox" id="dialog-vbox12">
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">3</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="dialog-action_area12">
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="HostKeyAcceptDialog.button_reject">
+                <property name="label" translatable="yes">Reject</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="image">StockStopImage</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="HostKeyAcceptDialog.button_accept">
+                <property name="label" translatable="yes">Accept</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="image">StockApplyImage</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="box25">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">5</property>
+            <child>
+              <object class="GtkBox" id="box26">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">center</property>
+                <property name="spacing">5</property>
+                <child>
+                  <object class="GtkImage" id="image2">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="stock">gtk-dialog-question</property>
+                    <property name="icon_size">6</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label61">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Accept Host Key?</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="scale" value="1.5"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label62">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">This host key has not been previously accepted. Accepting this
+host key now will store it to ensure that it does not change for
+future connections.</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFrame" id="frame1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="vexpand">True</property>
+                <property name="label_xalign">0</property>
+                <property name="shadow_type">none</property>
+                <child>
+                  <object class="GtkAlignment" id="alignment5">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="left_padding">12</property>
+                    <child>
+                      <object class="GtkScrolledWindow" id="scrolledwindow3">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="shadow_type">in</property>
+                        <child>
+                          <object class="GtkTextView" id="HostKeyAcceptDialog.textview_key_details">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="editable">False</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child type="label">
+                  <object class="GtkLabel" id="label63">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Host Key Details</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="-2">HostKeyAcceptDialog.button_reject</action-widget>
+      <action-widget response="-3">HostKeyAcceptDialog.button_accept</action-widget>
+    </action-widgets>
   </object>
   <object class="GtkDialog" id="TagEditorDialog">
     <property name="width_request">400</property>

--- a/data/client/king_phisher/king-phisher-client.ui
+++ b/data/client/king_phisher/king-phisher-client.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.19.0
+<!-- Generated with glade 3.19.0 
 
 Copyright (c) 2013-2015, SecureState LLC
 All rights reserved.
@@ -1820,180 +1820,6 @@ Brandan Geise</property>
     </child>
     <action-widgets>
       <action-widget response="-5">button1</action-widget>
-    </action-widgets>
-  </object>
-  <object class="GtkDialog" id="HostKeyWarnDialog">
-    <property name="width_request">450</property>
-    <property name="height_request">250</property>
-    <property name="can_focus">False</property>
-    <property name="resizable">False</property>
-    <property name="default_width">450</property>
-    <property name="default_height">-1</property>
-    <property name="destroy_with_parent">True</property>
-    <property name="type_hint">dialog</property>
-    <child internal-child="vbox">
-      <object class="GtkBox" id="dialog-vbox15">
-        <property name="can_focus">False</property>
-        <property name="orientation">vertical</property>
-        <property name="spacing">3</property>
-        <child internal-child="action_area">
-          <object class="GtkButtonBox" id="dialog-action_area15">
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
-            <child>
-              <object class="GtkButton" id="HostKeyWarnDialog.button_accept">
-                <property name="label" translatable="yes">Accept</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="image">StockStopImage</property>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="HostKeyWarnDialog.button_reject">
-                <property name="label" translatable="yes">Reject</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="image">StockApplyImage</property>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkBox" id="box27">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="orientation">vertical</property>
-            <property name="spacing">5</property>
-            <child>
-              <object class="GtkBox" id="box28">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">center</property>
-                <property name="spacing">5</property>
-                <child>
-                  <object class="GtkImage" id="image3">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="halign">end</property>
-                    <property name="stock">gtk-dialog-warning</property>
-                    <property name="icon_size">6</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="label64">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="halign">start</property>
-                    <property name="label" translatable="yes">Invalid Host Key!</property>
-                    <attributes>
-                      <attribute name="weight" value="bold"/>
-                      <attribute name="scale" value="1.5"/>
-                    </attributes>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="label65">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">This host key was previously intstored and has changed. It is
-possible that someone is intercepting your communications.
-It is also possible that the host key has changed. Please
-contact your system administrator.</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkFrame" id="frame3">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="vexpand">True</property>
-                <property name="label_xalign">0</property>
-                <property name="shadow_type">none</property>
-                <child>
-                  <object class="GtkAlignment" id="alignment7">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="left_padding">12</property>
-                    <child>
-                      <object class="GtkScrolledWindow" id="scrolledwindow4">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="shadow_type">in</property>
-                        <child>
-                          <object class="GtkTextView" id="HostKeyWarnDialog.textview_key_details">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="editable">False</property>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-                <child type="label">
-                  <object class="GtkLabel" id="label66">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Host Key Details</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-      </object>
-    </child>
-    <action-widgets>
-      <action-widget response="-3">HostKeyWarnDialog.button_reject</action-widget>
-      <action-widget response="-2">HostKeyWarnDialog.button_accept</action-widget>
     </action-widgets>
   </object>
   <object class="GtkBox" id="MailSenderEditTab">
@@ -4304,6 +4130,10 @@ contact your system administrator.</property>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox12">
         <property name="can_focus">False</property>
+        <property name="margin_left">10</property>
+        <property name="margin_right">10</property>
+        <property name="margin_top">5</property>
+        <property name="margin_bottom">5</property>
         <property name="orientation">vertical</property>
         <property name="spacing">3</property>
         <child internal-child="action_area">
@@ -4316,6 +4146,7 @@ contact your system administrator.</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
+                <property name="tooltip_text" translatable="yes">Reject the host key and abort the connection.</property>
                 <property name="image">StockStopImage</property>
               </object>
               <packing>
@@ -4330,6 +4161,7 @@ contact your system administrator.</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
+                <property name="tooltip_text" translatable="yes">Accept the host key and proceed with the connection.</property>
                 <property name="image">StockApplyImage</property>
               </object>
               <packing>
@@ -4420,7 +4252,9 @@ future connections.</property>
                   <object class="GtkAlignment" id="alignment5">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
+                    <property name="bottom_padding">3</property>
                     <property name="left_padding">12</property>
+                    <property name="right_padding">3</property>
                     <child>
                       <object class="GtkScrolledWindow" id="scrolledwindow3">
                         <property name="visible">True</property>
@@ -4463,6 +4297,205 @@ future connections.</property>
     <action-widgets>
       <action-widget response="-2">HostKeyAcceptDialog.button_reject</action-widget>
       <action-widget response="-3">HostKeyAcceptDialog.button_accept</action-widget>
+    </action-widgets>
+  </object>
+  <object class="GtkDialog" id="HostKeyWarnDialog">
+    <property name="width_request">450</property>
+    <property name="height_request">300</property>
+    <property name="can_focus">False</property>
+    <property name="resizable">False</property>
+    <property name="default_width">450</property>
+    <property name="destroy_with_parent">True</property>
+    <property name="type_hint">dialog</property>
+    <child internal-child="vbox">
+      <object class="GtkBox" id="dialog-vbox15">
+        <property name="can_focus">False</property>
+        <property name="margin_left">10</property>
+        <property name="margin_right">10</property>
+        <property name="margin_top">5</property>
+        <property name="margin_bottom">5</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">3</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="dialog-action_area15">
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="HostKeyWarnDialog.button_accept">
+                <property name="label" translatable="yes">Accept</property>
+                <property name="visible">True</property>
+                <property name="sensitive">False</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="tooltip_text" translatable="yes">Accept the host key and proceed with the connection.</property>
+                <property name="image">StockStopImage</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="HostKeyWarnDialog.button_reject">
+                <property name="label" translatable="yes">Reject</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="tooltip_text" translatable="yes">Reject the host key and abort the connection.</property>
+                <property name="image">StockApplyImage</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="box27">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">5</property>
+            <child>
+              <object class="GtkBox" id="box28">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">center</property>
+                <property name="spacing">5</property>
+                <child>
+                  <object class="GtkImage" id="image3">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="stock">gtk-dialog-warning</property>
+                    <property name="icon_size">6</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label64">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Invalid Host Key!</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="scale" value="1.5"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label65">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">&lt;b&gt;WARNING:&lt;/b&gt; This host key was previously stored and has
+changed. It is possible that someone is intercepting your
+communications. It is also possible that the host key has
+changed. Please contact your system administrator.</property>
+                <property name="use_markup">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFrame" id="frame3">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="vexpand">True</property>
+                <property name="label_xalign">0</property>
+                <property name="shadow_type">none</property>
+                <child>
+                  <object class="GtkAlignment" id="alignment7">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="bottom_padding">3</property>
+                    <property name="left_padding">12</property>
+                    <property name="right_padding">3</property>
+                    <child>
+                      <object class="GtkScrolledWindow" id="scrolledwindow4">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="shadow_type">in</property>
+                        <child>
+                          <object class="GtkTextView" id="HostKeyWarnDialog.textview_key_details">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="editable">False</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child type="label">
+                  <object class="GtkLabel" id="label66">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Host Key Details</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkCheckButton" id="HostKeyWarnDialog.checkbutton_accept_risk">
+                <property name="label" translatable="yes">I Accept The Risk</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="xalign">0</property>
+                <property name="draw_indicator">True</property>
+                <signal name="toggled" handler="signal_checkbutton_toggled" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="-3">HostKeyWarnDialog.button_accept</action-widget>
+      <action-widget response="-2">HostKeyWarnDialog.button_reject</action-widget>
     </action-widgets>
   </object>
   <object class="GtkDialog" id="TagEditorDialog">

--- a/data/client/king_phisher/king-phisher-client.ui
+++ b/data/client/king_phisher/king-phisher-client.ui
@@ -4412,10 +4412,10 @@ future connections.</property>
               <object class="GtkLabel" id="label65">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">&lt;b&gt;WARNING:&lt;/b&gt; This host key was previously stored and has
-changed. It is possible that someone is intercepting your
-communications. It is also possible that the host key has
-changed. Please contact your system administrator.</property>
+                <property name="label" translatable="yes">&lt;b&gt;WARNING:&lt;/b&gt; The remote host identification has changed.
+It is possible that someone is intercepting your communications.
+It is also possible that the host key has changed. Please contact
+the system administrator.</property>
                 <property name="use_markup">True</property>
               </object>
               <packing>

--- a/data/client/king_phisher/king-phisher-client.ui
+++ b/data/client/king_phisher/king-phisher-client.ui
@@ -4231,9 +4231,9 @@ Brandan Geise</property>
               <object class="GtkLabel" id="label62">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">This host key has not been previously accepted. Accepting this
-host key now will store it to ensure that it does not change for
-future connections.</property>
+                <property name="label" translatable="yes">This host and key have not been previously identified. If you trust this server,
+accept the host key to continue. Accepting this
+host key will store it for identification verification of future connections.</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -4412,10 +4412,9 @@ future connections.</property>
               <object class="GtkLabel" id="label65">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">&lt;b&gt;WARNING:&lt;/b&gt; The remote host identification has changed.
-It is possible that someone is intercepting your communications.
-It is also possible that the host key has changed. Please contact
-the system administrator.</property>
+                <property name="label" translatable="yes">&lt;b&gt;WARNING:&lt;/b&gt; The remote host identification has changed. Either
+the server's host key has changed or someone is intercepting
+your communications. Please contact the system administrator.</property>
                 <property name="use_markup">True</property>
               </object>
               <packing>

--- a/docs/source/change_log.rst
+++ b/docs/source/change_log.rst
@@ -7,6 +7,13 @@ Phisher.
 Version 1.x.x
 -------------
 
+Version 1.2.0
+^^^^^^^^^^^^^
+
+*In Progress*
+
+* SSH host key validation
+
 Version 1.1.0
 ^^^^^^^^^^^^^
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -67,6 +67,7 @@ intersphinx_mapping = {
 	'glib': ('http://lazka.github.io/pgi-docs/GLib-2.0/', None),
 	'gobject': ('http://lazka.github.io/pgi-docs/GObject-2.0/', None),
 	'gtk': ('http://lazka.github.io/pgi-docs/Gtk-3.0/', None),
+	'paramiko': ('http://docs.paramiko.org/en/latest/', None),
 	'smokezephyr': ('https://smoke-zephyr.readthedocs.org/en/latest/', None),
 	'webkit2': ('http://lazka.github.io/pgi-docs/WebKit2-4.0/', None)
 }

--- a/docs/source/king_phisher/client/dialogs/index.rst
+++ b/docs/source/king_phisher/client/dialogs/index.rst
@@ -12,4 +12,5 @@
    entry.rst
    exception.rst
    login.rst
+   ssh_host_key.rst
    tag_editor.rst

--- a/docs/source/king_phisher/client/dialogs/ssh_host_key.rst
+++ b/docs/source/king_phisher/client/dialogs/ssh_host_key.rst
@@ -1,0 +1,28 @@
+:mod:`dialogs.ssh_host_key`
+===========================
+
+.. module:: dialogs.ssh_host_key
+   :synopsis:
+
+Classes
+-------
+
+.. autoclass:: king_phisher.client.dialogs.ssh_host_key.BaseHostKeyDialog
+   :show-inheritance:
+   :members:
+   :special-members: __init__
+
+.. autoclass:: king_phisher.client.dialogs.ssh_host_key.HostKeyAcceptDialog
+   :show-inheritance:
+   :members:
+   :special-members: __init__
+
+.. autoclass:: king_phisher.client.dialogs.ssh_host_key.HostKeyWarnDialog
+   :show-inheritance:
+   :members:
+   :special-members: __init__
+
+.. autoclass:: king_phisher.client.dialogs.ssh_host_key.MissingHostKeyPolicy
+   :show-inheritance:
+   :members:
+   :special-members: __init__

--- a/docs/source/king_phisher/errors.rst
+++ b/docs/source/king_phisher/errors.rst
@@ -12,6 +12,10 @@ Exceptions
 .. autoexception:: king_phisher.errors.KingPhisherError
    :show-inheritance:
 
+.. autoexception:: king_phisher.errors.KingPhisherAbortError
+   :show-inheritance:
+   :members:
+
 .. autoexception:: king_phisher.errors.KingPhisherAbortRequestError
    :show-inheritance:
    :members:

--- a/king_phisher/client/application.py
+++ b/king_phisher/client/application.py
@@ -178,7 +178,7 @@ class KingPhisherClientApplication(_Gtk_Application):
 				username,
 				password,
 				('127.0.0.1', server_remote_port),
-				preferred_private_key=self.config['ssh_preferred_key'],
+				private_key=self.config.get('ssh_preferred_key'),
 				missing_host_key_policy=ssh_host_key.MissingHostKeyPolicy(self)
 			)
 			self._ssh_forwarder.start()

--- a/king_phisher/client/application.py
+++ b/king_phisher/client/application.py
@@ -48,6 +48,7 @@ from king_phisher import version
 from king_phisher.client import assistants
 from king_phisher.client import client_rpc
 from king_phisher.client import dialogs
+from king_phisher.client.dialogs import ssh_host_key
 from king_phisher.client import graphs
 from king_phisher.client import gui_utilities
 from king_phisher.client.windows import main
@@ -171,7 +172,14 @@ class KingPhisherClientApplication(_Gtk_Application):
 		server_remote_port = self.config['server_remote_port']
 
 		try:
-			self._ssh_forwarder = SSHTCPForwarder(server, username, password, ('127.0.0.1', server_remote_port), preferred_private_key=self.config['ssh_preferred_key'])
+			self._ssh_forwarder = SSHTCPForwarder(
+				server,
+				username,
+				password,
+				('127.0.0.1', server_remote_port),
+				preferred_private_key=self.config['ssh_preferred_key'],
+				missing_host_key_policy=ssh_host_key.HostKeyPolicy(self)
+			)
 			self._ssh_forwarder.start()
 		except paramiko.PasswordRequiredException:
 			gui_utilities.show_dialog_error(title_ssh_error, active_window, 'The specified SSH key requires a password.')

--- a/king_phisher/client/application.py
+++ b/king_phisher/client/application.py
@@ -41,6 +41,7 @@ import socket
 import sys
 import uuid
 
+from king_phisher import errors
 from king_phisher import find
 from king_phisher import json_ex
 from king_phisher import utilities
@@ -178,14 +179,18 @@ class KingPhisherClientApplication(_Gtk_Application):
 				password,
 				('127.0.0.1', server_remote_port),
 				preferred_private_key=self.config['ssh_preferred_key'],
-				missing_host_key_policy=ssh_host_key.HostKeyPolicy(self)
+				missing_host_key_policy=ssh_host_key.MissingHostKeyPolicy(self)
 			)
 			self._ssh_forwarder.start()
+		except errors.KingPhisherAbortError as error:
+			self.logger.info("ssh connection aborted ({0})".format(error.message))
 		except paramiko.PasswordRequiredException:
 			gui_utilities.show_dialog_error(title_ssh_error, active_window, 'The specified SSH key requires a password.')
 		except paramiko.AuthenticationException:
 			self.logger.warning('failed to authenticate to the remote ssh server')
 			gui_utilities.show_dialog_error(title_ssh_error, active_window, 'The server responded that the credentials are invalid.')
+		except paramiko.SSHException as error:
+			self.logger.warning("failed with ssh exception '{0}'".format(error.message))
 		except socket.error as error:
 			gui_utilities.show_dialog_exc_socket_error(error, active_window, title=title_ssh_error)
 		except Exception as error:

--- a/king_phisher/client/application.py
+++ b/king_phisher/client/application.py
@@ -173,6 +173,8 @@ class KingPhisherClientApplication(_Gtk_Application):
 		try:
 			self._ssh_forwarder = SSHTCPForwarder(server, username, password, ('127.0.0.1', server_remote_port), preferred_private_key=self.config['ssh_preferred_key'])
 			self._ssh_forwarder.start()
+		except paramiko.PasswordRequiredException:
+			gui_utilities.show_dialog_error(title_ssh_error, active_window, 'The specified SSH key requires a password.')
 		except paramiko.AuthenticationException:
 			self.logger.warning('failed to authenticate to the remote ssh server')
 			gui_utilities.show_dialog_error(title_ssh_error, active_window, 'The server responded that the credentials are invalid.')

--- a/king_phisher/client/dialogs/__init__.py
+++ b/king_phisher/client/dialogs/__init__.py
@@ -37,4 +37,5 @@ from .configuration import *
 from .entry import *
 from .exception import *
 from .login import *
+from .ssh_host_key import *
 from .tag_editor import *

--- a/king_phisher/client/dialogs/ssh_host_key.py
+++ b/king_phisher/client/dialogs/ssh_host_key.py
@@ -34,71 +34,66 @@ import base64
 import binascii
 import hashlib
 import logging
+import os
 
+from king_phisher import errors
 from king_phisher.client import gui_utilities
 
+from gi.repository import GLib
 from gi.repository import Gtk
 from gi.repository import Pango
 import paramiko
+import paramiko.hostkeys
 
 __all__ = ('HostKeyAcceptDialog', 'HostKeyWarnDialog')
 
-class HostKeyPolicy(paramiko.MissingHostKeyPolicy):
-	def __init__(self, application):
-		self.application = application
-		self.logger = logging.getLogger('KingPhisher.Client.' + self.__class__.__name__)
-		super(HostKeyPolicy, self).__init__()
-
-	def get_key_details(self, hostname, key):
-		name = key.get_name().lower()
-		if name.startswith('ssh-'):
-			name = name[4:]
-		name = name.split('-', 1)[0].upper()
-		details = ''
-		details += "{0} key fingerprint is SHA256:{1}.\n".format(name, base64.b64encode(hashlib.new('sha256', key.asbytes()).digest()))
-		details += "{0} key fingerprint is MD5:{1}.\n".format(name, binascii.b2a_hex(hashlib.new('md5', key.asbytes()).digest()))
-		return details
-
-	def missing_host_key(self, client, hostname, key):
-		config = self.application.config
-		known_hosts = config.get('ssh_known_hosts', {})
-		host_key_fingerprint = 'sha256:' + base64.b64encode(hashlib.new('sha256', key.asbytes()).digest())
-		host_key_string = "{0} {1}".format(key.get_name(), base64.b64encode(key.asbytes()))
-
-		key_details = self.get_key_details(hostname, key)
-		if not hostname in known_hosts:
-			dialog = HostKeyAcceptDialog(self.application, key_details)
-			if dialog.interact() != Gtk.ResponseType.ACCEPT:
-				raise RuntimeError()
-			known_hosts[hostname] = host_key_string
-		elif known_hosts[hostname] == host_key_string:
-			self.logger.debug("accepting known ssh host key {0} {1}".format(hostname, host_key_fingerprint))
-			return
-		else:
-			self.logger.warning("ssh host key does not match known value for {0}".format(hostname))
-			dialog = HostKeyWarnDialog(self.application, key_details)
-			if dialog.interact() != Gtk.ResponseType.ACCEPT:
-				raise RuntimeError()
-		config['ssh_known_hosts'] = known_hosts
-
-class HostKeyDialog(gui_utilities.GladeGObject):
+class BaseHostKeyDialog(gui_utilities.GladeGObject):
 	"""
+	A base class for dialogs which show information about SSH host keys. It is
+	assumed that the widgets defined in :py:attr:`.gobject_ids` are present
+	including one button to accept the host key, and one to reject. The class's
+	default response can be set using :py:attr:`.default_response`.
 	"""
-	gobject_ids = ('textview_key_details',)
+	gobject_ids = (
+		'button_accept',
+		'button_reject',
+		'textview_key_details'
+	)
 	top_gobject = 'dialog'
 	top_level_dependencies = (
 		'StockApplyImage',
 		'StockStopImage'
 	)
 	default_response = None
-	def __init__(self, application, key_details):
-		super(HostKeyDialog, self).__init__(application)
-		self.key_details = self.gtk_builder_get('textview_key_details')
-		self.key_details.modify_font(Pango.FontDescription('monospace 9'))
-		self.key_details.get_buffer().set_text(key_details)
+	"""The response that should be selected as the default for the dialog."""
+	def __init__(self, application, hostname, key):
+		"""
+		:param application: The application to associate this popup dialog with.
+		:type application: :py:class:`.KingPhisherClientApplication`
+		:param str hostname: The hostname associated with the key.
+		:param key: The host's SSH key.
+		:type: paramiko.PKey
+		"""
+		super(BaseHostKeyDialog, self).__init__(application)
+		self.hostname = hostname
+		self.key = key
+		textview = self.gobjects['textview_key_details']
+		textview.modify_font(Pango.FontDescription('monospace 9'))
+		textview.get_buffer().set_text(self.key_details)
 		if self.default_response is not None:
 			button = self.dialog.get_widget_for_response(response_id=self.default_response)
 			button.grab_default()
+
+	@property
+	def key_details(self):
+		key_type = self.key.get_name().lower()
+		details = "Host: {0} ({1})\n".format(self.hostname, key_type)
+		if key_type.startswith('ssh-'):
+			key_type = key_type[4:]
+		key_type = key_type.split('-', 1)[0].upper()
+		details += "{0} key fingerprint is SHA256:{1}.\n".format(key_type, base64.b64encode(hashlib.new('sha256', self.key.asbytes()).digest()))
+		details += "{0} key fingerprint is MD5:{1}.\n".format(key_type, binascii.b2a_hex(hashlib.new('md5', self.key.asbytes()).digest()))
+		return details
 
 	def interact(self):
 		self.dialog.show_all()
@@ -106,8 +101,64 @@ class HostKeyDialog(gui_utilities.GladeGObject):
 		self.dialog.destroy()
 		return response
 
-class HostKeyAcceptDialog(HostKeyDialog):
+class HostKeyAcceptDialog(BaseHostKeyDialog):
+	"""
+	A dialog that shows an SSH host key for a host that has not previously had
+	one associated with it.
+	"""
 	default_button = Gtk.ResponseType.ACCEPT
 
-class HostKeyWarnDialog(HostKeyDialog):
+class HostKeyWarnDialog(BaseHostKeyDialog):
+	"""
+	A dialog that warns about an SSH host key that does not match the one that
+	was previously stored for the host.
+	"""
 	default_button = Gtk.ResponseType.REJECT
+	def signal_checkbutton_toggled(self, button):
+		self.gobjects['button_accept'].set_sensitive(button.get_property('active'))
+
+class MissingHostKeyPolicy(paramiko.MissingHostKeyPolicy):
+	"""
+	A host key policy for use with paramiko that will validate SSH host keys
+	correctly. If a key is new, the user will be prompted with
+	:py:class:`.HostKeyAcceptDialog` dialog to accept it or if the host key does
+	not match the user will be warned with :py:class:`.HostKeyWarnDialog`. The
+	host keys accepted through this policy are stored in an OpenSSH compatible
+	"known_hosts" file using paramiko.
+	"""
+	def __init__(self, application):
+		"""
+		:param application: The application which is using this policy.
+		:type application: :py:class:`.KingPhisherClientApplication`
+		"""
+		self.application = application
+		self.logger = logging.getLogger('KingPhisher.Client.' + self.__class__.__name__)
+		super(MissingHostKeyPolicy, self).__init__()
+
+	def missing_host_key(self, client, hostname, key):
+		host_key_fingerprint = 'sha256:' + base64.b64encode(hashlib.new('sha256', key.asbytes()).digest())
+		host_keys = paramiko.hostkeys.HostKeys()
+		host_keys_modified = False
+		known_hosts_file = self.application.config.get('ssh_known_hosts_file', os.path.join(GLib.get_user_config_dir(), 'king-phisher', 'known_hosts'))
+
+		if os.access(known_hosts_file, os.R_OK):
+			host_keys.load(known_hosts_file)
+
+		if host_keys.lookup(hostname):
+			if host_keys.check(hostname, key):
+				self.logger.debug("accepting known ssh host key {0} {1}".format(hostname, host_key_fingerprint))
+				return
+			self.logger.warning("ssh host key does not match known value for {0}".format(hostname))
+			dialog = HostKeyWarnDialog(self.application, hostname, key)
+			if dialog.interact() != Gtk.ResponseType.ACCEPT:
+				raise errors.KingPhisherAbortError('bad ssh host key for ' + hostname)
+		else:
+			dialog = HostKeyAcceptDialog(self.application, hostname, key)
+			if dialog.interact() != Gtk.ResponseType.ACCEPT:
+				raise errors.KingPhisherAbortError('unknown ssh host key for ' + hostname)
+			host_keys.add(hostname, key.get_name(), key)
+			host_keys_modified = True
+
+		if host_keys_modified:
+			host_keys.save(known_hosts_file)
+			os.chmod(known_hosts_file, 0600)

--- a/king_phisher/client/dialogs/ssh_host_key.py
+++ b/king_phisher/client/dialogs/ssh_host_key.py
@@ -146,7 +146,7 @@ class MissingHostKeyPolicy(paramiko.MissingHostKeyPolicy):
 
 		if host_keys.lookup(hostname):
 			if host_keys.check(hostname, key):
-				self.logger.debug("accepting known ssh host key {0} {1}".format(hostname, host_key_fingerprint))
+				self.logger.debug("accepting known ssh host key {0} {1} {2}".format(hostname, key.get_name(), host_key_fingerprint))
 				return
 			self.logger.warning("ssh host key does not match known value for {0}".format(hostname))
 			dialog = HostKeyWarnDialog(self.application, hostname, key)

--- a/king_phisher/client/dialogs/ssh_host_key.py
+++ b/king_phisher/client/dialogs/ssh_host_key.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+#  king_phisher/client/dialogs/ssh_host_key.py
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following disclaimer
+#    in the documentation and/or other materials provided with the
+#    distribution.
+#  * Neither the name of the project nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+import base64
+import binascii
+import hashlib
+import logging
+
+from king_phisher.client import gui_utilities
+
+from gi.repository import Gtk
+from gi.repository import Pango
+import paramiko
+
+__all__ = ('HostKeyAcceptDialog', 'HostKeyWarnDialog')
+
+class HostKeyPolicy(paramiko.MissingHostKeyPolicy):
+	def __init__(self, application):
+		self.application = application
+		self.logger = logging.getLogger('KingPhisher.Client.' + self.__class__.__name__)
+		super(HostKeyPolicy, self).__init__()
+
+	def get_key_details(self, hostname, key):
+		name = key.get_name().lower()
+		if name.startswith('ssh-'):
+			name = name[4:]
+		name = name.split('-', 1)[0].upper()
+		details = ''
+		details += "{0} key fingerprint is SHA256:{1}.\n".format(name, base64.b64encode(hashlib.new('sha256', key.asbytes()).digest()))
+		details += "{0} key fingerprint is MD5:{1}.\n".format(name, binascii.b2a_hex(hashlib.new('md5', key.asbytes()).digest()))
+		return details
+
+	def missing_host_key(self, client, hostname, key):
+		config = self.application.config
+		known_hosts = config.get('ssh_known_hosts', {})
+		host_key_fingerprint = 'sha256:' + base64.b64encode(hashlib.new('sha256', key.asbytes()).digest())
+		host_key_string = "{0} {1}".format(key.get_name(), base64.b64encode(key.asbytes()))
+
+		key_details = self.get_key_details(hostname, key)
+		if not hostname in known_hosts:
+			dialog = HostKeyAcceptDialog(self.application, key_details)
+			if dialog.interact() != Gtk.ResponseType.ACCEPT:
+				raise RuntimeError()
+			known_hosts[hostname] = host_key_string
+		elif known_hosts[hostname] == host_key_string:
+			self.logger.debug("accepting known ssh host key {0} {1}".format(hostname, host_key_fingerprint))
+			return
+		else:
+			self.logger.warning("ssh host key does not match known value for {0}".format(hostname))
+			dialog = HostKeyWarnDialog(self.application, key_details)
+			if dialog.interact() != Gtk.ResponseType.ACCEPT:
+				raise RuntimeError()
+		config['ssh_known_hosts'] = known_hosts
+
+class HostKeyDialog(gui_utilities.GladeGObject):
+	"""
+	"""
+	gobject_ids = ('textview_key_details',)
+	top_gobject = 'dialog'
+	top_level_dependencies = (
+		'StockApplyImage',
+		'StockStopImage'
+	)
+	default_response = None
+	def __init__(self, application, key_details):
+		super(HostKeyDialog, self).__init__(application)
+		self.key_details = self.gtk_builder_get('textview_key_details')
+		self.key_details.modify_font(Pango.FontDescription('monospace 9'))
+		self.key_details.get_buffer().set_text(key_details)
+		if self.default_response is not None:
+			button = self.dialog.get_widget_for_response(response_id=self.default_response)
+			button.grab_default()
+
+	def interact(self):
+		self.dialog.show_all()
+		response = self.dialog.run()
+		self.dialog.destroy()
+		return response
+
+class HostKeyAcceptDialog(HostKeyDialog):
+	default_button = Gtk.ResponseType.ACCEPT
+
+class HostKeyWarnDialog(HostKeyDialog):
+	default_button = Gtk.ResponseType.REJECT

--- a/king_phisher/client/dialogs/ssh_host_key.py
+++ b/king_phisher/client/dialogs/ssh_host_key.py
@@ -72,7 +72,7 @@ class BaseHostKeyDialog(gui_utilities.GladeGObject):
 		:type application: :py:class:`.KingPhisherClientApplication`
 		:param str hostname: The hostname associated with the key.
 		:param key: The host's SSH key.
-		:type: paramiko.PKey
+		:type key: :py:class:`paramiko.pkey.PKey`
 		"""
 		super(BaseHostKeyDialog, self).__init__(application)
 		self.hostname = hostname

--- a/king_phisher/client/gui_utilities.py
+++ b/king_phisher/client/gui_utilities.py
@@ -433,7 +433,7 @@ class GladeGObject(object):
 	data file.
 	"""
 	gobject_ids = ()
-	"""A tuple of unique children GTK Builder IDs to load from the Glade data file. These must be prefixed with their GTK type in all lowecase."""
+	"""A tuple of unique children GTK Builder IDs to load from the Glade data file. These must be prefixed with their GTK type in all lowercase."""
 	top_level_dependencies = ()
 	"""Additional top level GObjects to load from the Glade data file."""
 	config_prefix = ''

--- a/king_phisher/client/mailer.py
+++ b/king_phisher/client/mailer.py
@@ -311,7 +311,7 @@ class MailSenderThread(threading.Thread):
 				username,
 				password,
 				remote_server,
-				preferred_private_key=self.config.get('ssh_preferred_key'),
+				private_key=self.config.get('ssh_preferred_key'),
 				missing_host_key_policy=ssh_host_key.MissingHostKeyPolicy(self.application)
 			)
 			self._ssh_forwarder.start()

--- a/king_phisher/client/tabs/mail.py
+++ b/king_phisher/client/tabs/mail.py
@@ -281,7 +281,7 @@ class MailSenderSendTab(gui_utilities.GladeGObject):
 		self.gobjects['button_mail_sender_start'].set_sensitive(False)
 		self.gobjects['button_mail_sender_stop'].set_sensitive(True)
 		self.progressbar.set_fraction(0)
-		self.sender_thread = mailer.MailSenderThread(self.config, self.config['mailer.target_file'], self.application.rpc, self)
+		self.sender_thread = mailer.MailSenderThread(self.application, self.config['mailer.target_file'], self.application.rpc, self)
 
 		# verify settings
 		missing_files = self.sender_thread.missing_files()

--- a/king_phisher/errors.py
+++ b/king_phisher/errors.py
@@ -37,7 +37,14 @@ class KingPhisherError(Exception):
 	"""
 	pass
 
-class KingPhisherAbortRequestError(KingPhisherError):
+class KingPhisherAbortError(KingPhisherError):
+	"""
+	An exception that can be raised to indicate that an arbitrary operation
+	needs to be aborted when no better method can be used.
+	"""
+	pass
+
+class KingPhisherAbortRequestError(KingPhisherAbortError):
 	"""
 	An exception that can be raised which when caught will cause the handler to
 	immediately stop processing the current request.

--- a/king_phisher/ssh_forward.py
+++ b/king_phisher/ssh_forward.py
@@ -173,9 +173,9 @@ class SSHTCPForwarder(threading.Thread):
 				private_key = KeyKlass.from_private_key(file_h)
 			except paramiko.PasswordRequiredException:
 				self.logger.warning("the user specified ssh key '{0}' is encrypted and requires a password".format(file_path))
+				raise
+			finally:
 				file_h.close()
-				return
-			file_h.close()
 			return private_key
 
 		#  if it's not one of the above, treat it like it's a fingerprint

--- a/king_phisher/ssh_forward.py
+++ b/king_phisher/ssh_forward.py
@@ -90,22 +90,24 @@ class ForwardHandler(socketserver.BaseRequestHandler):
 
 class SSHTCPForwarder(threading.Thread):
 	"""
-	Open an SSH connection and forward TCP traffic through it. If no
-	*missing_host_key_policy* is specified, :py:class:`paramiko.AutoAddPolicy`
-	will be used to accept all host keys.
+	Open an SSH connection and forward TCP traffic through it. A private key for
+	authentication can be specified as a string either by it's OpenSSH
+	fingerprint, as a file (prefixed with "file:"), or a raw key string
+	(prefixed with "key:"). If no *missing_host_key_policy* is specified,
+	:py:class:`paramiko.AutoAddPolicy` will be used to accept all host keys.
 
 	.. note::
 		This is a :py:class:`threading.Thread` object and needs to be started
 		after it is initialized.
 	"""
-	def __init__(self, server, username, password, remote_server, local_port=0, preferred_private_key=None, missing_host_key_policy=None):
+	def __init__(self, server, username, password, remote_server, local_port=0, private_key=None, missing_host_key_policy=None):
 		"""
 		:param tuple server: The server to connect to.
 		:param str username: The username to authenticate with.
 		:param str password: The password to authenticate with.
 		:param tuple remote_server: The remote server to connect to through the SSH server.
 		:param int local_port: The local port to forward, if not set a random one will be used.
-		:param str preferred_private_key: An RSA key to prefer for authentication.
+		:param str private_key: An RSA key to prefer for authentication.
 		:param missing_host_key_policy: The policy to use for missing host keys.
 		"""
 		super(SSHTCPForwarder, self).__init__()
@@ -126,11 +128,11 @@ class SSHTCPForwarder(threading.Thread):
 		# an issue seems to exist in paramiko when multiple keys are present through the ssh-agent
 		agent_keys = paramiko.Agent().get_keys()
 
-		if not self.__connected and preferred_private_key:
-			preferred_private_key = self.__resolve_private_key(preferred_private_key, agent_keys)
-			if preferred_private_key:
+		if not self.__connected and private_key:
+			private_key = self.__resolve_private_key(private_key, agent_keys)
+			if private_key:
 				self.logger.debug('attempting ssh authentication with user specified key')
-				self.__try_connect(look_for_keys=False, pkey=preferred_private_key)
+				self.__try_connect(look_for_keys=False, pkey=private_key)
 			else:
 				self.logger.warning('failed to identify the user specified key for ssh authentication')
 

--- a/king_phisher/ssh_forward.py
+++ b/king_phisher/ssh_forward.py
@@ -94,7 +94,8 @@ class SSHTCPForwarder(threading.Thread):
 	authentication can be specified as a string either by it's OpenSSH
 	fingerprint, as a file (prefixed with "file:"), or a raw key string
 	(prefixed with "key:"). If no *missing_host_key_policy* is specified,
-	:py:class:`paramiko.AutoAddPolicy` will be used to accept all host keys.
+	:py:class:`paramiko.client.AutoAddPolicy` will be used to accept all host
+	keys.
 
 	.. note::
 		This is a :py:class:`threading.Thread` object and needs to be started

--- a/king_phisher/ssh_forward.py
+++ b/king_phisher/ssh_forward.py
@@ -95,7 +95,7 @@ class SSHTCPForwarder(threading.Thread):
 	a :py:class:`threading.Thread` object and needs to be started after
 	it is initialized.
 	"""
-	def __init__(self, server, username, password, remote_server, local_port=0, preferred_private_key=None):
+	def __init__(self, server, username, password, remote_server, local_port=0, preferred_private_key=None, missing_host_key_policy=None):
 		"""
 		:param tuple server: The server to connect to.
 		:param str username: The username to authenticate with.
@@ -103,6 +103,7 @@ class SSHTCPForwarder(threading.Thread):
 		:param tuple remote_server: The remote server to connect to through the SSH server.
 		:param int local_port: The local port to forward, if not set a random one will be used.
 		:param str preferred_private_key: An RSA key to prefer for authentication.
+		:param missing_host_key_policy: The policy to use for missing host keys.
 		"""
 		super(SSHTCPForwarder, self).__init__()
 		self.logger = logging.getLogger('KingPhisher.' + self.__class__.__name__)
@@ -110,7 +111,9 @@ class SSHTCPForwarder(threading.Thread):
 		self.remote_server = (remote_server[0], int(remote_server[1]))
 		client = paramiko.SSHClient()
 		client.load_system_host_keys()
-		client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+		if missing_host_key_policy is None:
+			missing_host_key_policy = paramiko.AutoAddPolicy()
+		client.set_missing_host_key_policy(missing_host_key_policy)
 		self.client = client
 		self.username = username
 		self.__connected = False


### PR DESCRIPTION
This adds support for the client to store and validate the host keys for SSH connections. The first time a host is connected to, the user is prompted to accept the key. If the key changes after it's been stored a stern warning message will be displayed urging the user to abort the connection.

Keys are stored in `~/.config/king-phisher/known_hosts` next to the config file in an OpenSSH known_hosts format file.

Testing:
 - [x] Ensure the changes don't break compatibility for users updating (they'll just need to accept their server key the next time they connect)
 - [x] Verify a dialog is displayed and the verbiage makes sense when connecting to unknown hosts
 - [x] Verify a dialog is displayed and the verbiage makes sense when connecting to host with an invalid key