### PR TITLE
Install update

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -228,9 +228,6 @@ fi
 echo "Installing $LINUX_VERSION dependencies"
 if [ "$LINUX_VERSION" == "CentOS" ]; then
 	yum install -y epel-release
-	if
-		yum install -y centos-release-SCL
-		yum install python27
 	yum install -y freetype-devel gcc gcc-c++ libpng-devel make \
 		postgresql-devel python-devel python-pip
 	if [ "$KING_PHISHER_USE_POSTGRESQL" == "yes" ]; then

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -141,7 +141,7 @@ if [ -z "$LINUX_VERSION" -a $? -eq 0 ]; then
 	LINUX_VERSION="Debian"
 fi
 
-grep -E "Kali Linux 2\.[0-9]+" /etc/debian_version &> /dev/null
+grep 'Kali Linux 2\.[0-9]\|Kali Linux Rolling' /etc/debian_version &> /dev/null
 if [ -z "$LINUX_VERSION" -a $? -eq 0 ]; then
 	LINUX_VERSION="Kali"
 fi
@@ -228,6 +228,9 @@ fi
 echo "Installing $LINUX_VERSION dependencies"
 if [ "$LINUX_VERSION" == "CentOS" ]; then
 	yum install -y epel-release
+	if
+		yum install -y centos-release-SCL
+		yum install python27
 	yum install -y freetype-devel gcc gcc-c++ libpng-devel make \
 		postgresql-devel python-devel python-pip
 	if [ "$KING_PHISHER_USE_POSTGRESQL" == "yes" ]; then


### PR DESCRIPTION
install.sh scripted updated to support kali linux rolling.

- [ ] king-phisher/tools/install.sh successfully install King-Phisher on kali rolling.

* Note king-phisher is pre-packed with kali rolling, and installing from source should only be done if moving to the dev branch of king-phisher for testing or development work. 