### PR TITLE
Support An Alternative Python 2 ipaddress Module

### DIFF
--- a/KingPhisher
+++ b/KingPhisher
@@ -68,7 +68,7 @@ __requirements__ = [
 	'XlsxWriter>=0.7.7'
 ]
 if its.py_v2:
-	__requirements__.append('py2-ipaddress==3.4.1')
+	__requirements__.append('ipaddress>=1.0.16')
 
 def main():
 	parser = argparse.ArgumentParser(description='King Phisher Client GUI', conflict_handler='resolve')

--- a/KingPhisherServer
+++ b/KingPhisherServer
@@ -69,7 +69,7 @@ __requirements__ = [
 	'termcolor>=1.1.0'
 ]
 if its.py_v2:
-	__requirements__.append('py2-ipaddress==3.4.1')
+	__requirements__.append('ipaddress>=1.0.16')
 
 def main():
 	parser = argparse.ArgumentParser(description='King Phisher Server', conflict_handler='resolve')

--- a/docs/requirements.rtd.txt
+++ b/docs/requirements.rtd.txt
@@ -7,11 +7,11 @@ dnspython>=1.12.0
 geoip2>=2.2.0
 geojson>=1.3.1
 icalendar>=3.9.1
+ipaddress>=1.0.16
 Jinja2>=2.8
 markupsafe>=0.23
 msgpack-python>=0.4.6
 paramiko>=1.16.0
-py2-ipaddress==3.4.1
 pyotp>=2.0.1
 python-dateutil>=2.4.2
 python-pam>=1.8.2

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,8 +28,6 @@ sys.path.insert(2, _pkg)
 
 del _prj_root, _pkg
 
-sys.modules['ipaddress'] = type('ipaddress', (), {})
-
 import king_phisher.client
 import king_phisher.its
 import king_phisher.version
@@ -296,7 +294,6 @@ texinfo_documents = [
 MOCK_MODULES = [
 	'gi',
 	'gi.repository',
-	'ipaddress',
 	'matplotlib',
 	'matplotlib.backends',
 	'matplotlib.backends.backend_gtk3',

--- a/docs/source/king_phisher/ipaddress.rst
+++ b/docs/source/king_phisher/ipaddress.rst
@@ -18,6 +18,10 @@ Functions
 
 .. autofunction:: king_phisher.ipaddress.ip_interface
 
+.. autofunction:: king_phisher.ipaddress.is_loopback
+
+.. autofunction:: king_phisher.ipaddress.is_valid
+
 Classes
 -------
 

--- a/docs/source/king_phisher/ipaddress.rst
+++ b/docs/source/king_phisher/ipaddress.rst
@@ -1,0 +1,34 @@
+:mod:`ipaddress`
+================
+
+.. module:: ipaddress
+   :synopsis:
+
+This module provides functionality for dealing with an external "ipaddress"
+module in a Python 2 backwards compatible way. In Python 2 all string address
+arguments are converted to unicode which removes the ability to specify
+addresses as packed binary strings.
+
+Functions
+---------
+
+.. autofunction:: king_phisher.ipaddress.ip_address
+
+.. autofunction:: king_phisher.ipaddress.ip_network
+
+.. autofunction:: king_phisher.ipaddress.ip_interface
+
+Classes
+-------
+
+.. autoclass:: king_phisher.ipaddress.IPv4Address
+   :members:
+
+.. autoclass:: king_phisher.ipaddress.IPv4Network
+   :members:
+
+.. autoclass:: king_phisher.ipaddress.IPv6Address
+   :members:
+
+.. autoclass:: king_phisher.ipaddress.IPv6Network
+   :members:

--- a/docs/source/king_phisher/utilities.rst
+++ b/docs/source/king_phisher/utilities.rst
@@ -24,8 +24,6 @@ Functions
 
 .. autofunction:: king_phisher.utilities.is_valid_email_address
 
-.. autofunction:: king_phisher.utilities.is_valid_ip_address
-
 .. autofunction:: king_phisher.utilities.open_uri
 
 .. autofunction:: king_phisher.utilities.parse_datetime

--- a/docs/source/king_phisher_api.rst
+++ b/docs/source/king_phisher_api.rst
@@ -16,6 +16,7 @@ The King Phisher Package
    king_phisher/find.rst
    king_phisher/geoip.rst
    king_phisher/ics.rst
+   king_phisher/ipaddress.rst
    king_phisher/json_ex.rst
    king_phisher/scrubber.rst
    king_phisher/sms.rst

--- a/king_phisher/client/application.py
+++ b/king_phisher/client/application.py
@@ -31,7 +31,6 @@
 #
 
 import copy
-import ipaddress
 import logging
 import os
 import shlex
@@ -43,6 +42,7 @@ import uuid
 
 from king_phisher import errors
 from king_phisher import find
+from king_phisher import ipaddress
 from king_phisher import json_ex
 from king_phisher import utilities
 from king_phisher import version
@@ -427,7 +427,7 @@ class KingPhisherClientApplication(_Gtk_Application):
 		active_window = self.get_active_window()
 
 		server = parse_server(self.config['server'], 22)
-		if server[0] == 'localhost' or (utilities.is_valid_ip_address(server[0]) and ipaddress.ip_address(server[0]).is_loopback):
+		if server[0] == 'localhost' or (ipaddress.is_valid_ip_address(server[0]) and ipaddress.ip_address(server[0]).is_loopback):
 			local_server = ('localhost', self.config['server_remote_port'])
 			self.logger.info("connecting to local king phisher instance")
 		else:

--- a/king_phisher/client/application.py
+++ b/king_phisher/client/application.py
@@ -427,7 +427,7 @@ class KingPhisherClientApplication(_Gtk_Application):
 		active_window = self.get_active_window()
 
 		server = parse_server(self.config['server'], 22)
-		if server[0] == 'localhost' or (ipaddress.is_valid_ip_address(server[0]) and ipaddress.ip_address(server[0]).is_loopback):
+		if ipaddress.is_loopback(server[0]):
 			local_server = ('localhost', self.config['server_remote_port'])
 			self.logger.info("connecting to local king phisher instance")
 		else:

--- a/king_phisher/client/export.py
+++ b/king_phisher/client/export.py
@@ -34,7 +34,6 @@ import collections
 import copy
 import csv
 import datetime
-import ipaddress
 import logging
 import os
 import re
@@ -42,6 +41,7 @@ import shutil
 import xml.etree.ElementTree as ET
 
 from king_phisher import archive
+from king_phisher import ipaddress
 from king_phisher import json_ex
 from king_phisher import utilities
 from king_phisher.errors import KingPhisherInputValidationError

--- a/king_phisher/client/graphs.py
+++ b/king_phisher/client/graphs.py
@@ -31,10 +31,10 @@
 #
 
 import collections
-import ipaddress
 import string
 
 from king_phisher import color
+from king_phisher import ipaddress
 from king_phisher import its
 from king_phisher import ua_parser
 from king_phisher.client import gui_utilities

--- a/king_phisher/client/mailer.py
+++ b/king_phisher/client/mailer.py
@@ -45,7 +45,6 @@ import email.mime.multipart
 import email.mime.text
 import logging
 import mimetypes
-import ipaddress
 import os
 import smtplib
 import socket
@@ -55,6 +54,7 @@ import time
 
 from king_phisher import errors
 from king_phisher import ics
+from king_phisher import ipaddress
 from king_phisher import templates
 from king_phisher import utilities
 from king_phisher.client import gui_utilities
@@ -174,7 +174,7 @@ def guess_smtp_server_address(host, forward_host=None):
 	:rtype: None, :py:class:`ipaddress.IPv4Address`, :py:class:`ipaddress.IPv6Address`
 	"""
 	host = host.rsplit(':', 1)[0]
-	if utilities.is_valid_ip_address(host):
+	if ipaddress.is_valid_ip_address(host):
 		ip = ipaddress.ip_address(host)
 		if not ip.is_loopback:
 			return ip

--- a/king_phisher/client/mailer.py
+++ b/king_phisher/client/mailer.py
@@ -174,7 +174,7 @@ def guess_smtp_server_address(host, forward_host=None):
 	:rtype: None, :py:class:`ipaddress.IPv4Address`, :py:class:`ipaddress.IPv6Address`
 	"""
 	host = host.rsplit(':', 1)[0]
-	if ipaddress.is_valid_ip_address(host):
+	if ipaddress.is_valid(host):
 		ip = ipaddress.ip_address(host)
 		if not ip.is_loopback:
 			return ip

--- a/king_phisher/client/tabs/campaign.py
+++ b/king_phisher/client/tabs/campaign.py
@@ -31,12 +31,12 @@
 #
 
 import datetime
-import ipaddress
 import logging
 import threading
 import time
 
 from king_phisher import find
+from king_phisher import ipaddress
 from king_phisher import utilities
 from king_phisher.client import export
 from king_phisher.client import graphs

--- a/king_phisher/geoip.py
+++ b/king_phisher/geoip.py
@@ -33,13 +33,14 @@
 import collections
 import datetime
 import gzip
-import ipaddress
 import logging
 import os
 import shutil
 import sys
 import tempfile
 import threading
+
+from king_phisher import ipaddress
 
 import geoip2.database
 import geoip2.errors

--- a/king_phisher/ipaddress.py
+++ b/king_phisher/ipaddress.py
@@ -58,8 +58,23 @@ IPv4Network = ipaddress.IPv4Network
 IPv6Address = ipaddress.IPv6Address
 IPv6Network = ipaddress.IPv6Network
 
+def is_loopback(address):
+	"""
+	Check if an address is a loopback address or a common name for the loopback
+	interface.
+
+	:param str address: The address to check.
+	:return: Whether or not the address is a loopback address.
+	:rtype: bool
+	"""
+	if address == 'localhost':
+		return True
+	elif is_valid(address) and ip_address(address).is_loopback:
+		return True
+	return False
+
 @convert_address
-def is_valid_ip_address(address):
+def is_valid(address):
 	"""
 	Check that the string specified appears to be either a valid IPv4 or IPv6
 	address.

--- a/king_phisher/ipaddress.py
+++ b/king_phisher/ipaddress.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-#  tests/__init__.py
+#  king_phisher/ipaddress.py
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -30,24 +30,46 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-import logging
-logging.getLogger('KingPhisher').addHandler(logging.NullHandler)
-logging.getLogger('').setLevel(logging.CRITICAL)
-logging.captureWarnings(True)
+from __future__ import absolute_import
 
-from .client import *
-from .server import *
+import functools
+import ipaddress
 
-from .color import ColorConversionTests
-from .configuration import ServerConfigurationTests
-from .geoip import GeoIPTests
-from .geoip import GeoIPRPCTests
-from .ics import ICSTests
-from .ipaddress import IPAddressTests
-from .sms import SMSTests
-from .spf import SPFTests
-from .templates import TemplatesTests
-from .ua_parser import UserAgentParserTests
-from .utilities import UtilitiesTests
-from .version import VersionTests
-from .xor import XORTests
+from king_phisher import its
+
+def convert_address(callable):
+	if not its.py_v2:
+		return callable
+	@functools.wraps(callable)
+	def wrapper(address, *args, **kwargs):
+		if isinstance(address, str):
+			address = address.decode('utf-8')
+		return callable(address, *args, **kwargs)
+	return wrapper
+
+ip_address = convert_address(ipaddress.ip_address)
+ip_network = convert_address(ipaddress.ip_network)
+ip_interface = convert_address(ipaddress.ip_interface)
+
+AddressValueError = ipaddress.AddressValueError
+
+IPv4Address = ipaddress.IPv4Address
+IPv4Network = ipaddress.IPv4Network
+IPv6Address = ipaddress.IPv6Address
+IPv6Network = ipaddress.IPv6Network
+
+@convert_address
+def is_valid_ip_address(address):
+	"""
+	Check that the string specified appears to be either a valid IPv4 or IPv6
+	address.
+
+	:param str address: The IP address to validate.
+	:return: Whether the IP address appears to be valid or not.
+	:rtype: bool
+	"""
+	try:
+		ipaddress.ip_address(address)
+	except ValueError:
+		return False
+	return True

--- a/king_phisher/ipaddress.py
+++ b/king_phisher/ipaddress.py
@@ -37,14 +37,14 @@ import ipaddress
 
 from king_phisher import its
 
-def convert_address(callable):
+def convert_address(func):
 	if not its.py_v2:
-		return callable
-	@functools.wraps(callable)
+		return func
+	@functools.wraps(func)
 	def wrapper(address, *args, **kwargs):
 		if isinstance(address, str):
 			address = address.decode('utf-8')
-		return callable(address, *args, **kwargs)
+		return func(address, *args, **kwargs)
 	return wrapper
 
 ip_address = convert_address(ipaddress.ip_address)

--- a/king_phisher/server/rest_api.py
+++ b/king_phisher/server/rest_api.py
@@ -30,11 +30,11 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-import ipaddress
 import json
 import logging
 
 from king_phisher import geoip
+from king_phisher import ipaddress
 from king_phisher import sms
 from king_phisher import utilities
 

--- a/king_phisher/server/server.py
+++ b/king_phisher/server/server.py
@@ -32,7 +32,6 @@
 
 import base64
 import binascii
-import ipaddress
 import json
 import logging
 import os
@@ -43,6 +42,7 @@ import threading
 from king_phisher import errors
 from king_phisher import find
 from king_phisher import geoip
+from king_phisher import ipaddress
 from king_phisher import sms
 from king_phisher import templates
 from king_phisher import utilities
@@ -392,7 +392,7 @@ class KingPhisherRequestHandler(server_rpc.KingPhisherRequestHandlerRPC, Advance
 		else:
 			# treat cookie_value ad an IPv4 address
 			cookie_value = cookie_value.split(':', 1)[0]
-		if utilities.is_valid_ip_address(cookie_value):
+		if ipaddress.is_valid_ip_address(cookie_value):
 			address = cookie_value
 		return address
 

--- a/king_phisher/server/server.py
+++ b/king_phisher/server/server.py
@@ -392,7 +392,7 @@ class KingPhisherRequestHandler(server_rpc.KingPhisherRequestHandlerRPC, Advance
 		else:
 			# treat cookie_value ad an IPv4 address
 			cookie_value = cookie_value.split(':', 1)[0]
-		if ipaddress.is_valid_ip_address(cookie_value):
+		if ipaddress.is_valid(cookie_value):
 			address = cookie_value
 		return address
 

--- a/king_phisher/server/server_rpc.py
+++ b/king_phisher/server/server_rpc.py
@@ -32,12 +32,12 @@
 
 import datetime
 import functools
-import ipaddress
 import logging
 import threading
 
 from king_phisher import errors
 from king_phisher import geoip
+from king_phisher import ipaddress
 from king_phisher import version
 from king_phisher.constants import ConnectionErrorReason
 from king_phisher.server.database import manager as db_manager

--- a/king_phisher/spf.py
+++ b/king_phisher/spf.py
@@ -30,10 +30,11 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-import ipaddress
 import logging
 import re
 
+from king_phisher import ipaddress
+from king_phisher import its
 from king_phisher.constants import SPFResult
 
 import dns.exception
@@ -267,6 +268,8 @@ class SenderPolicyFramework(object):
 			return self._check_host(ip, rvalue, sender, top_level=False) == SPFResult.PASS
 		elif mechanism == 'ip4':
 			try:
+				if its.py_v2 and isinstance(rvalue, str):
+					rvalue = rvalue.decode('utf-8')
 				ip_network = ipaddress.IPv4Network(rvalue, strict=False)
 			except ipaddress.AddressValueError:
 				raise SPFPermError('failed to parse spf data')
@@ -274,6 +277,8 @@ class SenderPolicyFramework(object):
 				return True
 		elif mechanism == 'ip6':
 			try:
+				if its.py_v2 and isinstance(rvalue, str):
+					rvalue = rvalue.decode('utf-8')
 				ip_network = ipaddress.IPv6Network(rvalue, strict=False)
 			except ipaddress.AddressValueError:
 				raise SPFPermError('failed to parse spf data')

--- a/king_phisher/utilities.py
+++ b/king_phisher/utilities.py
@@ -33,7 +33,6 @@
 import collections
 import datetime
 import inspect
-import ipaddress
 import logging
 import operator
 import os
@@ -273,21 +272,6 @@ def is_valid_email_address(email_address):
 	if email_address == None:
 		return False
 	return EMAIL_REGEX.match(email_address) != None
-
-def is_valid_ip_address(ip_address):
-	"""
-	Check that the string specified appears to be either a valid IPv4 or IPv6
-	address.
-
-	:param str ip_address: The IP address to validate.
-	:return: Whether the IP address appears to be valid or not.
-	:rtype: bool
-	"""
-	try:
-		ipaddress.ip_address(ip_address)
-	except ValueError:
-		return False
-	return True
 
 def open_uri(uri):
 	"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,13 +7,13 @@ dnspython>=1.12.0
 geoip2>=2.2.0
 geojson>=1.3.1
 icalendar>=3.9.1
+ipaddress>=1.0.16
 Jinja2>=2.8
 markupsafe>=0.23
 matplotlib>=1.5.0
 msgpack-python>=0.4.6
 paramiko>=1.16.0
 psycopg2>=2.6.1
-py2-ipaddress==3.4.1
 pyotp>=2.0.1
 python-dateutil>=2.4.2
 python-pam>=1.8.2

--- a/tests/geoip.py
+++ b/tests/geoip.py
@@ -30,11 +30,11 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-import ipaddress
 import os
 import unittest
 
 from king_phisher import geoip
+from king_phisher import ipaddress
 from king_phisher.testing import KingPhisherTestCase
 from king_phisher.testing import KingPhisherServerTestCase
 
@@ -77,7 +77,7 @@ class GeoIPTests(KingPhisherTestCase):
 		for field in geoip.DB_RESULT_FIELDS:
 			self.assertEqual(getattr(loc, field), getattr(loc_raw, field))
 		self.assertIsInstance(loc.ip_address, ipaddress.IPv4Address)
-		self.assertEqual(loc.ip_address, ipaddress.IPv4Address(GEO_TEST_IP))
+		self.assertEqual(loc.ip_address, ipaddress.ip_address(GEO_TEST_IP))
 
 class GeoIPRPCTests(KingPhisherServerTestCase):
 	def test_geoip_lookup_rpc(self):

--- a/tests/ipaddress.py
+++ b/tests/ipaddress.py
@@ -50,9 +50,9 @@ class IPAddressTests(testing.KingPhisherTestCase):
 			''
 		]
 		for address in valid_ips:
-			self.assertTrue(ipaddress.is_valid_ip_address(address))
+			self.assertTrue(ipaddress.is_valid(address))
 		for address in invalid_ips:
-			self.assertFalse(ipaddress.is_valid_ip_address(address))
+			self.assertFalse(ipaddress.is_valid(address))
 
 if __name__ == '__main__':
 	unittest.main()

--- a/tests/ipaddress.py
+++ b/tests/ipaddress.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-#  tests/__init__.py
+#  tests/utilities.py
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -30,24 +30,29 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-import logging
-logging.getLogger('KingPhisher').addHandler(logging.NullHandler)
-logging.getLogger('').setLevel(logging.CRITICAL)
-logging.captureWarnings(True)
+import unittest
 
-from .client import *
-from .server import *
+from king_phisher import ipaddress
+from king_phisher import testing
 
-from .color import ColorConversionTests
-from .configuration import ServerConfigurationTests
-from .geoip import GeoIPTests
-from .geoip import GeoIPRPCTests
-from .ics import ICSTests
-from .ipaddress import IPAddressTests
-from .sms import SMSTests
-from .spf import SPFTests
-from .templates import TemplatesTests
-from .ua_parser import UserAgentParserTests
-from .utilities import UtilitiesTests
-from .version import VersionTests
-from .xor import XORTests
+class IPAddressTests(testing.KingPhisherTestCase):
+	def test_is_valid_ip_address(self):
+		valid_ips = [
+			'127.0.0.1',
+			'10.0.0.1',
+			'200.100.0.1',
+			'fe80::1',
+			'::1'
+		]
+		invalid_ips = [
+			'localhost',
+			'www.google.com',
+			''
+		]
+		for address in valid_ips:
+			self.assertTrue(ipaddress.is_valid_ip_address(address))
+		for address in invalid_ips:
+			self.assertFalse(ipaddress.is_valid_ip_address(address))
+
+if __name__ == '__main__':
+	unittest.main()

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -63,24 +63,6 @@ class UtilitiesTests(testing.KingPhisherTestCase):
 		for address in invalid_emails:
 			self.assertFalse(utilities.is_valid_email_address(address))
 
-	def test_is_valid_ip_address(self):
-		valid_ips = [
-			'127.0.0.1',
-			'10.0.0.1',
-			'200.100.0.1',
-			'fe80::1',
-			'::1'
-		]
-		invalid_ips = [
-			'localhost',
-			'www.google.com',
-			''
-		]
-		for address in valid_ips:
-			self.assertTrue(utilities.is_valid_ip_address(address))
-		for address in invalid_ips:
-			self.assertFalse(utilities.is_valid_ip_address(address))
-
 	def test_mock_calls(self):
 		mock = utilities.Mock()
 		result = mock()


### PR DESCRIPTION
This adds support for using an alternative [ipaddress](https://pypi.python.org/pypi/ipaddress) module for Python 2.7 support. This wraps the module and normalizes the usage of the `address` paramter from a `str` to `unicode` to make it compatible with the currently used `py2-ipaddress` module.

**Notice:** To keep the package list clean, `py2-ipaddress` should be uninstalled with pip BEFORE `ipaddress` is installed in it's place.