### PR TITLE
Updated line 123 to include BackBox Linux 4.5

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -120,7 +120,7 @@ if [ "$(id -u)" != "0" ]; then
 	exit $E_NOTROOT
 fi
 
-grep -E "BackBox Linux 4\.[2-4]" /etc/issue &> /dev/null
+grep -E "BackBox Linux 4\.[2-5]" /etc/issue &> /dev/null
 if [ -z "$LINUX_VERSION" -a $? -eq 0 ]; then
 	LINUX_VERSION="BackBox"
 fi


### PR DESCRIPTION
The original check only checked for BackBox Linux 4.2 through 4.4.  I updated the check to include 4.5 as well.