### PR TITLE
Fix Style For BackBox 4.5 / Gtk 3.10

### DIFF
--- a/data/client/king_phisher/king-phisher-client.ui
+++ b/data/client/king_phisher/king-phisher-client.ui
@@ -5682,9 +5682,6 @@ your communications. Please contact the system administrator.</property>
                     <property name="position">0</property>
                   </packing>
                 </child>
-                <style>
-                  <class name="background-add"/>
-                </style>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -5700,6 +5697,7 @@ your communications. Please contact the system administrator.</property>
                 <property name="expanded">True</property>
                 <property name="spacing">5</property>
                 <signal name="activate" handler="signal_expander_activate_message_type" swapped="no"/>
+                <signal name="notify::expanded" handler="signal_expander_notify_expanded" swapped="no"/>
                 <child>
                   <object class="GtkGrid" id="grid11">
                     <property name="visible">True</property>
@@ -5799,6 +5797,7 @@ your communications. Please contact the system administrator.</property>
                 <property name="expanded">True</property>
                 <property name="spacing">5</property>
                 <signal name="activate" handler="signal_expander_activate_message_type" swapped="no"/>
+                <signal name="notify::expanded" handler="signal_expander_notify_expanded" swapped="no"/>
                 <child>
                   <object class="GtkGrid" id="grid12">
                     <property name="visible">True</property>
@@ -6074,6 +6073,9 @@ your communications. Please contact the system administrator.</property>
             </child>
           </object>
         </child>
+        <style>
+          <class name="background-add"/>
+        </style>
       </object>
     </child>
   </object>

--- a/data/client/king_phisher/style/theme.css
+++ b/data/client/king_phisher/style/theme.css
@@ -310,6 +310,9 @@ GtkSwitch.slider {
 
 .notebook tab {
   padding: 4px 10px 5px 10px;
+  background-color: transparent;
+  background-image: none;
+  border-color: transparent;
 }
 
 .notebook tab:active {
@@ -340,21 +343,15 @@ GtkTreeView row:selected {
   color: @theme_color_tv_hofg;
 }
 
-GtkWindow {
-  background-image: url("./background.svg");
-  background-size: 100% 100%;
-}
-
-GtkWindow:active,
-GtkWindow:hover {
-  color: white;
-}
-
 GtkLabel {
   background: none;
   color: white;
   padding-left: 4px;
   padding-right: 4px;
+}
+
+GtkRadioButton {
+  background-image: none;
 }
 
 GtkSpinButton {
@@ -369,8 +366,18 @@ GtkToolbar {
   background-image: none;
 }
 
-GtkRadioButton {
-  background-image: none;
+GtkViewport {
+  background-color: @theme_color_bg;
+}
+
+GtkWindow {
+  background-image: url("./background.svg");
+  background-size: 100% 100%;
+}
+
+GtkWindow:active,
+GtkWindow:hover {
+  color: white;
 }
 
 .titlebar {

--- a/king_phisher/client/gui_utilities.py
+++ b/king_phisher/client/gui_utilities.py
@@ -614,6 +614,8 @@ class GladeGObject(GladeGObjectMeta('_GladeGObject', (object,), {})):
 		from the corresponding value in the :py:attr:`~.GladeGObject.config`.
 		"""
 		for gobject_id, gobject in self.gobjects.items():
+			if not '_' in gobject_id:
+				continue
 			gtype, config_name = gobject_id.split('_', 1)
 			config_name = self.config_prefix + config_name
 			if not gtype in GOBJECT_PROPERTY_MAP or not config_name in self.config:
@@ -628,6 +630,8 @@ class GladeGObject(GladeGObjectMeta('_GladeGObject', (object,), {})):
 
 	def objects_save_to_config(self):
 		for gobject_id, gobject in self.gobjects.items():
+			if not '_' in gobject_id:
+				continue
 			gtype, config_name = gobject_id.split('_', 1)
 			config_name = self.config_prefix + config_name
 			if not gtype in GOBJECT_PROPERTY_MAP:

--- a/king_phisher/client/tabs/mail.py
+++ b/king_phisher/client/tabs/mail.py
@@ -751,7 +751,8 @@ class MailSenderConfigurationTab(gui_utilities.GladeGObject):
 			'radiobutton_target_type_single',
 			'spinbutton_calendar_invite_duration',
 			'spinbutton_calendar_invite_start_hour',
-			'spinbutton_calendar_invite_start_minute'
+			'spinbutton_calendar_invite_start_minute',
+			'viewport'
 		),
 		top_level=(
 			'ClockHourAdjustment',
@@ -854,6 +855,10 @@ class MailSenderConfigurationTab(gui_utilities.GladeGObject):
 		button = self.message_type.buttons[message_type]
 		with gui_utilities.gobject_signal_blocked(button, 'toggled'):
 			self.message_type.set_active(message_type)
+
+	def signal_expander_notify_expanded(self, expander, _):
+		if expander.get_expanded():
+			self.gobjects['viewport'].queue_draw()
 
 	def signal_kpc_campaign_load(self, _, campaign_id):
 		campaign = self.application.rpc.remote_table_row('campaigns', campaign_id, cache=True, refresh=True)


### PR DESCRIPTION
This PR fixes the style of GtkViewport and GtkNotebook tabs as reported in issue #73. This makes the mailer config tab visible and not all white in the client for BackBox 4.5. Additionally this fixes the color of the inactive GtkNotebook tabs. The GtkViewport issue was addressed by setting the background to be an image, this was the desired way to do it but resulted in an odd visual quark when the widget changed sizes due to the message type changing back and forth from calendar to email. This issue was addressed by subscribing to the `GtkExpander notify::expanded` signal and forcing the viewport to be redrawn.

Testing:
 - [x] Load the PR in BackBox 4.5 and make sure the GUI appears relatively normal.*

\* Relatively because of the differences between GTK 3.10 and newer it's not *exactly* the same.