### PR TITLE
updated install script to handle issues with apt-get update package c…

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -179,6 +179,15 @@ else
 	fi
 fi
 
+# update apt-get package information and only continue if successful
+if [ "$(command -v apt-get)" ]; then
+	echo "attempting to update apt-get cache pacakge information"
+	apt-get update
+	if [ ! $? = 0 ]; then
+		echo "apt-get update failed, please correct issues then try again"
+		exit
+fi
+
 # install git if necessary
 if [ ! "$(command -v git)" ]; then
 	if [ "$LINUX_VERSION" == "CentOS" ]; then

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -186,6 +186,7 @@ if [ "$(command -v apt-get)" ]; then
 	if [ ! $? = 0 ]; then
 		echo "apt-get update failed, please correct issues then try again"
 		exit
+	fi
 fi
 
 # install git if necessary


### PR DESCRIPTION
@zeroSteiner 

Update the tools/install.sh script to handle the issues identified in #79. apt-get update package cache was not update for installation, and sometimes fails when apt-get update occurs. Install script will now attempt to do apt-get update, and exit if it fails.

Example to run
```BASH
tools/install.sh
```
To test:
change source.list file so its wrong to force a 'fail'
- [ ]  script should exit on failing apt-get update

change source.list file back to normal.
- [ ] script should complete successfully
