### PR TITLE
Client Plugin Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 *.yml
 .pylintrc
 build/*
-data/*/king_phisher/plugins/*
+data/*/king_phisher/plugins*
 dist/*
 docs/build/*
 docs/html/*

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 *.yml
 .pylintrc
 build/*
-data/*/king_phisher/plugins*
 dist/*
 docs/build/*
 docs/html/*

--- a/KingPhisher
+++ b/KingPhisher
@@ -60,6 +60,7 @@ __requirements__ = [
 	'icalendar>=3.9.2',
 	'Jinja2>=2.8',
 	'paramiko>=1.16.0',
+	'pluginbase>=0.3',
 	'python-dateutil>=2.5.1',
 	'pytz>=2016.1',
 	'requests>=2.9.1',

--- a/KingPhisher
+++ b/KingPhisher
@@ -74,11 +74,13 @@ def main():
 	parser = argparse.ArgumentParser(description='King Phisher Client GUI', conflict_handler='resolve')
 	utilities.argp_add_args(parser, default_root='KingPhisher')
 	parser.add_argument('-c', '--config', dest='config_file', required=False, help='specify a configuration file to use')
+	parser.add_argument('--no-plugins', dest='use_plugins', default=True, action='store_false', help='disable all plugins')
 	parser.add_argument('--no-style', dest='use_style', default=True, action='store_false', help='disable interface styling')
 	arguments = parser.parse_args()
 
 	utilities.configure_stream_logger(arguments.loglvl, arguments.logger)
 	config_file = arguments.config_file
+	use_plugins = arguments.use_plugins
 	use_style = arguments.use_style
 	del arguments, parser
 	logger = logging.getLogger('KingPhisher.Client.CLI')
@@ -116,7 +118,7 @@ def main():
 	start_time = time.time()
 	logger.debug('using ui data from glade file: ' + gui_utilities.which_glade())
 	try:
-		app = application.KingPhisherClientApplication(config_file=config_file, use_style=use_style)
+		app = application.KingPhisherClientApplication(config_file=config_file, use_plugins=use_plugins, use_style=use_style)
 	except Exception as error:
 		logger.critical("initialization error: {0} ({1})".format(error.__class__.__name__, getattr(error, 'message', 'n/a')))
 		color.print_error('failed to initialize the King Phisher client')

--- a/data/client/king_phisher/client_config.json
+++ b/data/client/king_phisher/client_config.json
@@ -9,6 +9,7 @@
   "filter.campaign.user": true,
   "filter.campaign.other_users": false,
   "plugins": {},
+  "plugins.enabled": [],
   "remove_attachment_metadata": true,
   "rpc.serializer": null,
   "server": "localhost:22",

--- a/data/client/king_phisher/client_config.json
+++ b/data/client/king_phisher/client_config.json
@@ -8,6 +8,7 @@
   "filter.campaign.expired": false,
   "filter.campaign.user": true,
   "filter.campaign.other_users": false,
+  "plugins": {},
   "remove_attachment_metadata": true,
   "rpc.serializer": null,
   "server": "localhost:22",

--- a/data/client/king_phisher/king-phisher-client.ui
+++ b/data/client/king_phisher/king-phisher-client.ui
@@ -2421,7 +2421,7 @@ Spencer McIntyre</property>
   </object>
   <object class="GtkApplicationWindow" id="PluginManagerWindow">
     <property name="width_request">550</property>
-    <property name="height_request">250</property>
+    <property name="height_request">300</property>
     <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Plugin Manager</property>
@@ -2462,7 +2462,7 @@ Spencer McIntyre</property>
             <property name="can_focus">True</property>
             <child>
               <object class="GtkScrolledWindow" id="PluginManagerWindow.scrolledwindow_plugin_info">
-                <property name="height_request">100</property>
+                <property name="height_request">125</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="border_width">3</property>
@@ -2509,7 +2509,7 @@ Spencer McIntyre</property>
                           </object>
                           <packing>
                             <property name="left_attach">0</property>
-                            <property name="top_attach">1</property>
+                            <property name="top_attach">2</property>
                           </packing>
                         </child>
                         <child>
@@ -2526,7 +2526,7 @@ Spencer McIntyre</property>
                           </object>
                           <packing>
                             <property name="left_attach">2</property>
-                            <property name="top_attach">1</property>
+                            <property name="top_attach">2</property>
                           </packing>
                         </child>
                         <child>
@@ -2542,7 +2542,7 @@ Spencer McIntyre</property>
                           </object>
                           <packing>
                             <property name="left_attach">1</property>
-                            <property name="top_attach">1</property>
+                            <property name="top_attach">2</property>
                           </packing>
                         </child>
                         <child>
@@ -2558,7 +2558,7 @@ Spencer McIntyre</property>
                           </object>
                           <packing>
                             <property name="left_attach">3</property>
-                            <property name="top_attach">1</property>
+                            <property name="top_attach">2</property>
                           </packing>
                         </child>
                         <child>
@@ -2575,7 +2575,7 @@ Spencer McIntyre</property>
                           </object>
                           <packing>
                             <property name="left_attach">0</property>
-                            <property name="top_attach">2</property>
+                            <property name="top_attach">3</property>
                           </packing>
                         </child>
                         <child>
@@ -2592,9 +2592,30 @@ Spencer McIntyre</property>
                           </object>
                           <packing>
                             <property name="left_attach">1</property>
-                            <property name="top_attach">2</property>
+                            <property name="top_attach">3</property>
                             <property name="width">3</property>
                           </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_homepage">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">&lt;a href=""&gt;Homepage&lt;/a&gt;</property>
+                            <property name="use_markup">True</property>
+                            <property name="track_visited_links">False</property>
+                            <signal name="activate-link" handler="signal_label_activate_link" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">1</property>
+                            <property name="width">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
                         </child>
                       </object>
                     </child>

--- a/data/client/king_phisher/king-phisher-client.ui
+++ b/data/client/king_phisher/king-phisher-client.ui
@@ -2420,7 +2420,7 @@ Spencer McIntyre</property>
     </data>
   </object>
   <object class="GtkApplicationWindow" id="PluginManagerWindow">
-    <property name="width_request">400</property>
+    <property name="width_request">550</property>
     <property name="height_request">250</property>
     <property name="can_focus">False</property>
     <property name="border_width">5</property>
@@ -2428,18 +2428,193 @@ Spencer McIntyre</property>
     <property name="window_position">center-on-parent</property>
     <property name="destroy_with_parent">True</property>
     <child>
-      <object class="GtkScrolledWindow" id="scrolledwindow6">
+      <object class="GtkBox" id="box29">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="shadow_type">in</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
         <child>
-          <object class="GtkTreeView" id="PluginManagerWindow.treeview_plugins">
+          <object class="GtkScrolledWindow" id="scrolledwindow6">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
-            <child internal-child="selection">
-              <object class="GtkTreeSelection" id="treeview-selection12"/>
+            <property name="shadow_type">in</property>
+            <child>
+              <object class="GtkTreeView" id="PluginManagerWindow.treeview_plugins">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="activate_on_single_click">True</property>
+                <signal name="row-activated" handler="signal_treeview_row_activated" swapped="no"/>
+                <child internal-child="selection">
+                  <object class="GtkTreeSelection" id="treeview-selection12"/>
+                </child>
+              </object>
             </child>
           </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkExpander" id="PluginManagerWindow.expander_plugin_info">
+            <property name="visible">True</property>
+            <property name="sensitive">False</property>
+            <property name="can_focus">True</property>
+            <child>
+              <object class="GtkScrolledWindow" id="PluginManagerWindow.scrolledwindow_plugin_info">
+                <property name="height_request">100</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="border_width">3</property>
+                <property name="hscrollbar_policy">never</property>
+                <property name="shadow_type">in</property>
+                <child>
+                  <object class="GtkViewport" id="PluginManagerWindow.viewport_plugin_info">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkGrid" id="grid13">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="row_spacing">3</property>
+                        <property name="column_spacing">3</property>
+                        <property name="column_homogeneous">True</property>
+                        <child>
+                          <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_title">
+                            <property name="visible">True</property>
+                            <property name="sensitive">False</property>
+                            <property name="can_focus">False</property>
+                            <attributes>
+                              <attribute name="weight" value="bold"/>
+                              <attribute name="scale" value="1.25"/>
+                            </attributes>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">0</property>
+                            <property name="width">4</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_for_authors">
+                            <property name="visible">True</property>
+                            <property name="sensitive">False</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">end</property>
+                            <property name="valign">start</property>
+                            <property name="label" translatable="yes">Authors:</property>
+                            <attributes>
+                              <attribute name="scale" value="0.90000000000000002"/>
+                            </attributes>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_for_version">
+                            <property name="visible">True</property>
+                            <property name="sensitive">False</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">end</property>
+                            <property name="valign">start</property>
+                            <property name="label" translatable="yes">Version:</property>
+                            <attributes>
+                              <attribute name="scale" value="0.90000000000000002"/>
+                            </attributes>
+                          </object>
+                          <packing>
+                            <property name="left_attach">2</property>
+                            <property name="top_attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_authors">
+                            <property name="visible">True</property>
+                            <property name="sensitive">False</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="valign">start</property>
+                            <attributes>
+                              <attribute name="scale" value="0.90000000000000002"/>
+                            </attributes>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_version">
+                            <property name="visible">True</property>
+                            <property name="sensitive">False</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="valign">start</property>
+                            <attributes>
+                              <attribute name="scale" value="0.90000000000000002"/>
+                            </attributes>
+                          </object>
+                          <packing>
+                            <property name="left_attach">3</property>
+                            <property name="top_attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_for_description">
+                            <property name="visible">True</property>
+                            <property name="sensitive">False</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">end</property>
+                            <property name="valign">start</property>
+                            <property name="label" translatable="yes">Description:</property>
+                            <attributes>
+                              <attribute name="scale" value="0.90000000000000002"/>
+                            </attributes>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_description">
+                            <property name="visible">True</property>
+                            <property name="sensitive">False</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="valign">start</property>
+                            <property name="wrap">True</property>
+                            <attributes>
+                              <attribute name="scale" value="0.90000000000000002"/>
+                            </attributes>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">2</property>
+                            <property name="width">3</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child type="label">
+              <object class="GtkLabel" id="label44">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Plugin Information</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
         </child>
       </object>
     </child>

--- a/data/client/king_phisher/king-phisher-client.ui
+++ b/data/client/king_phisher/king-phisher-client.ui
@@ -2428,12 +2428,12 @@ Spencer McIntyre</property>
     <property name="window_position">center-on-parent</property>
     <property name="destroy_with_parent">True</property>
     <child>
-      <object class="GtkBox" id="box29">
+      <object class="GtkBox" id="PluginManagerWindow.box_main">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
         <child>
-          <object class="GtkScrolledWindow" id="scrolledwindow6">
+          <object class="GtkScrolledWindow" id="PluginManagerWindow.scrolledwindow_plugins">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="shadow_type">in</property>
@@ -2444,7 +2444,7 @@ Spencer McIntyre</property>
                 <property name="activate_on_single_click">True</property>
                 <signal name="row-activated" handler="signal_treeview_row_activated" swapped="no"/>
                 <child internal-child="selection">
-                  <object class="GtkTreeSelection" id="treeview-selection12"/>
+                  <object class="GtkTreeSelection" id="PluginManagerWindow.treeview_selection_plugins"/>
                 </child>
               </object>
             </child>
@@ -2473,7 +2473,7 @@ Spencer McIntyre</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <child>
-                      <object class="GtkGrid" id="grid13">
+                      <object class="GtkGrid" id="PluginManagerWindow.grid_plugin_info">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="row_spacing">3</property>
@@ -2648,7 +2648,7 @@ Spencer McIntyre</property>
               </object>
             </child>
             <child type="label">
-              <object class="GtkLabel" id="label44">
+              <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Plugin Information</property>

--- a/data/client/king_phisher/king-phisher-client.ui
+++ b/data/client/king_phisher/king-phisher-client.ui
@@ -2513,27 +2513,11 @@ Spencer McIntyre</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_for_version">
-                            <property name="visible">True</property>
-                            <property name="sensitive">False</property>
-                            <property name="can_focus">False</property>
-                            <property name="halign">end</property>
-                            <property name="valign">start</property>
-                            <property name="label" translatable="yes">Version:</property>
-                            <attributes>
-                              <attribute name="scale" value="0.90000000000000002"/>
-                            </attributes>
-                          </object>
-                          <packing>
-                            <property name="left_attach">2</property>
-                            <property name="top_attach">2</property>
-                          </packing>
-                        </child>
-                        <child>
                           <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_authors">
                             <property name="visible">True</property>
                             <property name="sensitive">False</property>
                             <property name="can_focus">False</property>
+                            <property name="tooltip_text" translatable="yes">The contributors who have written and provided this plugin.</property>
                             <property name="halign">start</property>
                             <property name="valign">start</property>
                             <attributes>
@@ -2550,6 +2534,7 @@ Spencer McIntyre</property>
                             <property name="visible">True</property>
                             <property name="sensitive">False</property>
                             <property name="can_focus">False</property>
+                            <property name="tooltip_text" translatable="yes">The version identifier of this plugin.</property>
                             <property name="halign">start</property>
                             <property name="valign">start</property>
                             <attributes>
@@ -2558,7 +2543,7 @@ Spencer McIntyre</property>
                           </object>
                           <packing>
                             <property name="left_attach">3</property>
-                            <property name="top_attach">2</property>
+                            <property name="top_attach">1</property>
                           </packing>
                         </child>
                         <child>
@@ -2583,6 +2568,7 @@ Spencer McIntyre</property>
                             <property name="visible">True</property>
                             <property name="sensitive">False</property>
                             <property name="can_focus">False</property>
+                            <property name="tooltip_text" translatable="yes">The description of this plugin and the features it provides.</property>
                             <property name="halign">start</property>
                             <property name="valign">start</property>
                             <property name="wrap">True</property>
@@ -2597,25 +2583,63 @@ Spencer McIntyre</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_homepage">
+                          <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_for_version">
+                            <property name="visible">True</property>
+                            <property name="sensitive">False</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">end</property>
+                            <property name="valign">start</property>
+                            <property name="label" translatable="yes">Version:</property>
+                            <attributes>
+                              <attribute name="scale" value="0.90000000000000002"/>
+                            </attributes>
+                          </object>
+                          <packing>
+                            <property name="left_attach">2</property>
+                            <property name="top_attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_for_compatible">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
+                            <property name="halign">end</property>
+                            <property name="valign">start</property>
+                            <property name="label" translatable="yes">Compatible:</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_compatible">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="tooltip_text" translatable="yes">Whether or not this plugin is compatible with this environment.</property>
+                            <property name="halign">start</property>
+                            <property name="valign">start</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_homepage">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="tooltip_text" translatable="yes">The home page of this plugin.</property>
                             <property name="label" translatable="yes">&lt;a href=""&gt;Homepage&lt;/a&gt;</property>
                             <property name="use_markup">True</property>
                             <property name="track_visited_links">False</property>
                             <signal name="activate-link" handler="signal_label_activate_link" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="left_attach">1</property>
-                            <property name="top_attach">1</property>
+                            <property name="left_attach">2</property>
+                            <property name="top_attach">2</property>
                             <property name="width">2</property>
                           </packing>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
                         </child>
                       </object>
                     </child>

--- a/data/client/king_phisher/king-phisher-client.ui
+++ b/data/client/king_phisher/king-phisher-client.ui
@@ -44,7 +44,8 @@ Spencer McIntyre
   <!-- interface-authors Spencer McIntyre\nJeff McCutchan\nBrandan Geise -->
   <object class="GtkAboutDialog" id="AboutDialog">
     <property name="can_focus">False</property>
-    <property name="type_hint">menu</property>
+    <property name="type">popup</property>
+    <property name="type_hint">dialog</property>
     <property name="program_name">King Phisher</property>
     <property name="copyright" translatable="yes">Copyright (c) 2013-2016, SecureState LLC</property>
     <property name="comments" translatable="yes">Phishing Campaign Toolkit</property>
@@ -2418,6 +2419,31 @@ Spencer McIntyre</property>
       </row>
     </data>
   </object>
+  <object class="GtkApplicationWindow" id="PluginManagerWindow">
+    <property name="width_request">400</property>
+    <property name="height_request">250</property>
+    <property name="can_focus">False</property>
+    <property name="border_width">5</property>
+    <property name="title" translatable="yes">Plugin Manager</property>
+    <property name="window_position">center-on-parent</property>
+    <property name="destroy_with_parent">True</property>
+    <child>
+      <object class="GtkScrolledWindow" id="scrolledwindow6">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="shadow_type">in</property>
+        <child>
+          <object class="GtkTreeView" id="PluginManagerWindow.treeview_plugins">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <child internal-child="selection">
+              <object class="GtkTreeSelection" id="treeview-selection12"/>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </object>
   <object class="GtkAdjustment" id="PortAdjustment">
     <property name="lower">1</property>
     <property name="upper">65535</property>
@@ -4405,6 +4431,16 @@ Spencer McIntyre</property>
                 <property name="label" translatable="yes">Clone Web Page</property>
                 <property name="use_underline">True</property>
                 <signal name="activate" handler="do_tools_clone_page" swapped="no"/>
+              </object>
+            </child>
+            <child>
+              <object class="GtkMenuItem" id="MainMenuBar.menuitem_tools_manage_plugins">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="accel_path">&lt;KingPhisherClient&gt;/Tools/Manage Plugins</property>
+                <property name="label" translatable="yes">Manage Plugins</property>
+                <property name="use_underline">True</property>
+                <signal name="activate" handler="do_tools_manage_plugins" swapped="no"/>
               </object>
             </child>
             <child>

--- a/data/client/king_phisher/king-phisher-client.ui
+++ b/data/client/king_phisher/king-phisher-client.ui
@@ -3051,11 +3051,11 @@ Spencer McIntyre</property>
           </packing>
         </child>
         <child>
-          <object class="GtkNotebook" id="ConfigurationDialog.notebook1">
+          <object class="GtkNotebook" id="ConfigurationDialog.notebook_config">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <child>
-              <object class="GtkBox" id="box2">
+              <object class="GtkBox" id="ConfigurationDialog.box_server_tab">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">start</property>
@@ -3300,7 +3300,7 @@ Spencer McIntyre</property>
               </packing>
             </child>
             <child>
-              <object class="GtkScrolledWindow" id="scrolledwindow5">
+              <object class="GtkScrolledWindow" id="ConfigurationDialog.scrolledwindow_smtp_tab">
                 <property name="height_request">0</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
@@ -3557,7 +3557,7 @@ Spencer McIntyre</property>
               </packing>
             </child>
             <child>
-              <object class="GtkBox" id="box3">
+              <object class="GtkBox" id="ConfigurationDialog.box_campaign_tab">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">start</property>
@@ -3617,7 +3617,7 @@ Spencer McIntyre</property>
               </packing>
             </child>
             <child>
-              <object class="GtkBox" id="box1">
+              <object class="GtkBox" id="ConfigurationDialog.box_client_tab">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">start</property>
@@ -3862,6 +3862,62 @@ Spencer McIntyre</property>
               </object>
               <packing>
                 <property name="position">3</property>
+                <property name="tab_fill">False</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkScrolledWindow" id="ConfigurationDialog.scrolledwindow_plugins_tab">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="hscrollbar_policy">never</property>
+                <property name="shadow_type">in</property>
+                <child>
+                  <object class="GtkViewport" id="ConfigurationDialog.viewport_plugins_tab">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkBox" id="ConfigurationDialog.box_plugin_options">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">3</property>
+                        <child>
+                          <object class="GtkLabel" id="label46">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Plugins with configurable options can have those options set here.</property>
+                            <property name="justify">center</property>
+                            <property name="wrap">True</property>
+                            <attributes>
+                              <attribute name="style" value="italic"/>
+                            </attributes>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="position">4</property>
+              </packing>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel" id="label45">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Plugins</property>
+              </object>
+              <packing>
+                <property name="position">4</property>
                 <property name="tab_fill">False</property>
               </packing>
             </child>

--- a/data/client/king_phisher/plugins/check_for_updates.py
+++ b/data/client/king_phisher/plugins/check_for_updates.py
@@ -1,0 +1,61 @@
+import distutils.version
+
+import king_phisher.version as version
+import king_phisher.client.plugins as plugins
+import king_phisher.client.gui_utilities as gui_utilities
+
+import requests
+
+StrictVersion = distutils.version.StrictVersion
+
+def release_to_version(release):
+	return StrictVersion(release['tag_name'][1:])
+
+def get_latest_release():
+	releases = requests.get('https://api.github.com/repos/securestate/king-phisher/releases').json()
+	releases = [release for release in releases if not release['draft']]
+	releases = sorted(
+		releases,
+		key=release_to_version,
+		reverse=True
+	)
+	return releases[0]
+
+class Plugin(plugins.ClientPlugin):
+	authors = ['Spencer McIntyre']
+	title = 'Check For Updates'
+	description = """
+	Automatically check for updates to the King Phisher project by inspecting
+	the latest GitHub releases. If a new version has been released, the user
+	will be notified with a dialog box after logging into the server.
+	"""
+	homepage = 'https://github.com/securestate/king-phisher'
+	req_min_version = '1.0'
+	def initialize(self):
+		self.signal_connect('server-connected', self.signal_server_connected)
+		return True
+
+	def signal_server_connected(self, _):
+		release = get_latest_release()
+		self.logger.info('found latest release: ' + release['tag_name'])
+		client_version = StrictVersion(version.distutils_version)
+		release_version = release_to_version(release)
+		server_version = self.application.rpc('version')['version_info']
+		server_version = StrictVersion("{major}.{minor}.{micro}".format(**server_version))
+		out_of_date = None
+
+		if release_version > client_version:
+			out_of_date = 'Client'
+		elif release_version > server_version:
+			out_of_date = 'Server'
+		if out_of_date is None:
+			return
+
+		gui_utilities.show_dialog_info(
+			'New Version Available',
+			self.application.main_window,
+			"The King Phisher {part} is out of date,\n"
+			"<a href=\"{release[html_url]}\">{release[tag_name]}</a> is now available.".format(part=out_of_date, release=release),
+			secondary_use_markup=True
+		)
+

--- a/data/client/king_phisher/style/theme.css
+++ b/data/client/king_phisher/style/theme.css
@@ -32,7 +32,7 @@
  *   - Emily Gundry
  *   - Spencer McIntyre
  *
- * For reference the source to the default GTK theme Adwaita can be found here:
+ * For reference, the source to the default GTK theme Adwaita can be found here:
  * https://github.com/GNOME/gtk/tree/master/gtk/theme/Adwaita
  *
  * Complex widgets that are defined in gtk/ui (i.e. GtkFileChooserDialog) can

--- a/data/server/king_phisher/server_config.yml
+++ b/data/server/king_phisher/server_config.yml
@@ -40,7 +40,7 @@ server:
   # details
   database: sqlite:////var/king-phisher/king-phisher.db
 
-  # The Postgres database to use
+  # The PostgreSQL database to use
   #database: postgresql://user:pass@localhost/king_phisher
 
   # Fork the server process into the background

--- a/data/zsh/_KingPhisher
+++ b/data/zsh/_KingPhisher
@@ -40,6 +40,8 @@
 
 _arguments \
   "--logger[specify the root logger]:logger" \
+  "--no-plugins[disable all plugins]" \
+  "--no-style[disable interface styling]" \
   {-L,--log}"[set the logging level]:loglvl:(DEBUG INFO WARNING ERROR CRITICAL)" \
   {-c,--config}"[specify a configuration file to use]:config file" \
   {-h,--help}"[show help text]" \

--- a/docs/source/change_log.rst
+++ b/docs/source/change_log.rst
@@ -15,6 +15,7 @@ Version 1.3.0
 * Added automatic setup of PostgreSQL database for the server
 * Server bug fixes when running on non-standard HTTP ports
 * Added completion to the messaged editor
+* Support for plugins in the client application
 
 Version 1.2.0
 ^^^^^^^^^^^^^

--- a/docs/source/king_phisher/client/application.rst
+++ b/docs/source/king_phisher/client/application.rst
@@ -10,11 +10,11 @@ client application.
 Data
 ----
 
-.. autodata:: king_phisher.client.application.CONFIG_FILE_PATH
-
 .. autodata:: king_phisher.client.application.DISABLED
 
 .. autodata:: king_phisher.client.application.GTK3_DEFAULT_THEME
+
+.. autodata:: king_phisher.client.application.USER_DATA_PATH
 
 Classes
 -------

--- a/docs/source/king_phisher/client/gui_utilities.rst
+++ b/docs/source/king_phisher/client/gui_utilities.rst
@@ -38,6 +38,8 @@ Functions
 
 .. autofunction:: king_phisher.client.gui_utilities.gtk_treeview_selection_to_clipboard
 
+.. autofunction:: king_phisher.client.gui_utilities.gtk_treeview_selection_iterate
+
 .. autofunction:: king_phisher.client.gui_utilities.gtk_treeview_set_column_titles
 
 .. autofunction:: king_phisher.client.gui_utilities.gtk_widget_destroy_children

--- a/docs/source/king_phisher/client/index.rst
+++ b/docs/source/king_phisher/client/index.rst
@@ -19,9 +19,10 @@ application.
    windows/index.rst
 
    application.rst
+   client_rpc.rst
    export.rst
    graphs.rst
    gui_utilities.rst
    mailer.rst
-   client_rpc.rst
+   plugins.rst
    web_cloner.rst

--- a/docs/source/king_phisher/client/plugins.rst
+++ b/docs/source/king_phisher/client/plugins.rst
@@ -7,6 +7,36 @@
 Classes
 -------
 
+.. autoclass:: king_phisher.client.plugins.ClientOptionBoolean
+   :show-inheritance:
+   :members:
+   :inherited-members:
+   :special-members: __init__
+
+.. autoclass:: king_phisher.client.plugins.ClientOptionEnum
+   :show-inheritance:
+   :members:
+   :inherited-members:
+   :special-members: __init__
+
+.. autoclass:: king_phisher.client.plugins.ClientOptionInteger
+   :show-inheritance:
+   :members:
+   :inherited-members:
+   :special-members: __init__
+
+.. autoclass:: king_phisher.client.plugins.ClientOptionMixin
+   :show-inheritance:
+   :members:
+   :inherited-members:
+   :special-members: __init__
+
+.. autoclass:: king_phisher.client.plugins.ClientOptionString
+   :show-inheritance:
+   :members:
+   :inherited-members:
+   :special-members: __init__
+
 .. autoclass:: king_phisher.client.plugins.ClientPlugin
    :show-inheritance:
    :members:

--- a/docs/source/king_phisher/client/plugins.rst
+++ b/docs/source/king_phisher/client/plugins.rst
@@ -1,0 +1,16 @@
+:mod:`client.plugins`
+=====================
+
+.. module:: client.plugins
+   :synopsis:
+
+Classes
+-------
+
+.. autoclass:: king_phisher.client.plugins.ClientPlugin
+   :show-inheritance:
+   :members:
+
+.. autoclass:: king_phisher.client.plugins.ClientPluginManager
+   :show-inheritance:
+   :members:

--- a/docs/source/king_phisher/client/windows/index.rst
+++ b/docs/source/king_phisher/client/windows/index.rst
@@ -9,5 +9,6 @@ client application.
    :titlesonly:
 
    main.rst
+   plugin_manager.rst
    rpc_terminal.rst
 

--- a/docs/source/king_phisher/client/windows/plugin_manager.rst
+++ b/docs/source/king_phisher/client/windows/plugin_manager.rst
@@ -1,0 +1,16 @@
+:mod:`client.windows.plugin_manager`
+====================================
+
+.. module:: client.windows.plugin_manager
+   :synopsis:
+
+This module provides the window through which the user can enable and disable
+plugins.
+
+Classes
+-------
+
+.. autoclass:: king_phisher.client.windows.plugin_manager.PluginManagerWindow
+   :show-inheritance:
+   :members:
+   :special-members: __init__

--- a/docs/source/king_phisher/errors.rst
+++ b/docs/source/king_phisher/errors.rst
@@ -30,5 +30,8 @@ Exceptions
 .. autoexception:: king_phisher.errors.KingPhisherPermissionError
    :show-inheritance:
 
+.. autoexception:: king_phisher.errors.KingPhisherResourceError
+   :show-inheritance:
+
 .. autoexception:: king_phisher.errors.KingPhisherTimeoutError
    :show-inheritance:

--- a/docs/source/king_phisher/plugins.rst
+++ b/docs/source/king_phisher/plugins.rst
@@ -10,6 +10,35 @@ plugins.
 Classes
 -------
 
+.. autoclass:: king_phisher.plugins.OptionBase
+   :show-inheritance:
+   :members:
+   :special-members: __init__
+
+.. autoclass:: king_phisher.plugins.OptionBoolean
+   :show-inheritance:
+   :members:
+   :inherited-members:
+   :special-members: __init__
+
+.. autoclass:: king_phisher.plugins.OptionEnum
+   :show-inheritance:
+   :members:
+   :inherited-members:
+   :special-members: __init__
+
+.. autoclass:: king_phisher.plugins.OptionInteger
+   :show-inheritance:
+   :members:
+   :inherited-members:
+   :special-members: __init__
+
+.. autoclass:: king_phisher.plugins.OptionString
+   :show-inheritance:
+   :members:
+   :inherited-members:
+   :special-members: __init__
+
 .. autoclass:: king_phisher.plugins.PluginBase
    :show-inheritance:
    :members:

--- a/docs/source/king_phisher/plugins.rst
+++ b/docs/source/king_phisher/plugins.rst
@@ -1,0 +1,21 @@
+:mod:`plugins`
+==============
+
+.. module:: plugins
+   :synopsis:
+
+This module provides the core functionality necessary to support user provided
+plugins.
+
+Classes
+-------
+
+.. autoclass:: king_phisher.plugins.PluginBase
+   :show-inheritance:
+   :members:
+   :special-members: __init__
+
+.. autoclass:: king_phisher.plugins.PluginManagerBase
+   :show-inheritance:
+   :members:
+   :special-members: __init__

--- a/docs/source/king_phisher/plugins.rst
+++ b/docs/source/king_phisher/plugins.rst
@@ -15,6 +15,11 @@ Classes
    :members:
    :special-members: __init__
 
+.. autoclass:: king_phisher.plugins.PluginBaseMeta
+   :show-inheritance:
+   :members:
+   :special-members: __init__
+
 .. autoclass:: king_phisher.plugins.PluginManagerBase
    :show-inheritance:
    :members:

--- a/docs/source/king_phisher_api.rst
+++ b/docs/source/king_phisher_api.rst
@@ -18,6 +18,7 @@ The King Phisher Package
    king_phisher/ics.rst
    king_phisher/ipaddress.rst
    king_phisher/json_ex.rst
+   king_phisher/plugins.rst
    king_phisher/scrubber.rst
    king_phisher/sms.rst
    king_phisher/smtp_server.rst

--- a/king_phisher/client/application.py
+++ b/king_phisher/client/application.py
@@ -320,8 +320,16 @@ class KingPhisherClientApplication(_Gtk_Application):
 		self.main_window.set_position(Gtk.WindowPosition.CENTER)
 		self.main_window.show()
 
-		for name in self.config['plugins'].keys():
-			self.plugin_manager.enable(name)
+		for name in list(self.config['plugins.enabled']):
+			try:
+				self.plugin_manager.enable(name)
+			except errors.KingPhisherResourceError:
+				self.config['plugins.enabled'].remove(name)
+				gui_utilities.show_dialog_error(
+					'Failed To Enable Plugin',
+					self.main_window,
+					"Plugin '{0}' could not be enabled.".format(name)
+				)
 
 	def do_campaign_changed(self, campaign_id):
 		pass

--- a/king_phisher/client/application.py
+++ b/king_phisher/client/application.py
@@ -156,6 +156,8 @@ class KingPhisherClientApplication(_Gtk_Application):
 			[os.path.join(USER_DATA_PATH, 'plugins'), find.find_data_directory('plugins')],
 			self
 		)
+		if use_plugins:
+			self.plugin_manager.load_all()
 
 	def _create_actions(self):
 		action = Gio.SimpleAction.new('emit-application-signal', GLib.VariantType.new('s'))
@@ -206,7 +208,7 @@ class KingPhisherClientApplication(_Gtk_Application):
 			self.logger.warning('failed to authenticate to the remote ssh server')
 			gui_utilities.show_dialog_error(title_ssh_error, active_window, 'The server responded that the credentials are invalid.')
 		except paramiko.SSHException as error:
-			self.logger.warning("failed with ssh exception '{0}'".format(error.message))
+			self.logger.warning("failed with ssh exception '{0}'".format(error.args[0]))
 		except socket.error as error:
 			gui_utilities.show_dialog_exc_socket_error(error, active_window, title=title_ssh_error)
 		except Exception as error:

--- a/king_phisher/client/application.py
+++ b/king_phisher/client/application.py
@@ -322,8 +322,9 @@ class KingPhisherClientApplication(_Gtk_Application):
 
 		for name in list(self.config['plugins.enabled']):
 			try:
+				self.plugin_manager.load(name)
 				self.plugin_manager.enable(name)
-			except errors.KingPhisherResourceError:
+			except Exception:
 				self.config['plugins.enabled'].remove(name)
 				gui_utilities.show_dialog_error(
 					'Failed To Enable Plugin',

--- a/king_phisher/client/application.py
+++ b/king_phisher/client/application.py
@@ -109,7 +109,7 @@ class KingPhisherClientApplication(_Gtk_Application):
 		'rpc-cache-clear': (GObject.SIGNAL_RUN_FIRST, None, ()),
 		'server-connected': (GObject.SIGNAL_RUN_LAST, None, ())
 	}
-	def __init__(self, config_file=None, use_style=True):
+	def __init__(self, config_file=None, use_plugins=True, use_style=True):
 		super(KingPhisherClientApplication, self).__init__()
 		if use_style:
 			self._theme_file = 'theme.css'
@@ -149,6 +149,9 @@ class KingPhisherClientApplication(_Gtk_Application):
 		self.actions = {}
 		self._create_actions()
 
+		if not use_plugins:
+			self.logger.info('disabling all plugins')
+			self.config['plugins.enabled'] = []
 		self.plugin_manager = plugins.ClientPluginManager(
 			[os.path.join(USER_DATA_PATH, 'plugins'), find.find_data_directory('plugins')],
 			self

--- a/king_phisher/client/dialogs/configuration.py
+++ b/king_phisher/client/dialogs/configuration.py
@@ -159,7 +159,7 @@ class ConfigurationDialog(gui_utilities.GladeGObject):
 
 	def _configure_settings_plugins(self):
 		pm = self.application.plugin_manager
-		plugin_klasses = [klass for _, klass in pm if klass.options]
+		plugin_klasses = [klass for _, klass in pm if klass.options and klass.is_compatible]
 		plugin_klasses = sorted(plugin_klasses, key=lambda k: k.title)
 		for plugin_klass in plugin_klasses:
 			self._configure_settings_plugin_options(plugin_klass)

--- a/king_phisher/client/gui_utilities.py
+++ b/king_phisher/client/gui_utilities.py
@@ -267,6 +267,22 @@ def gtk_treesortable_sort_func_numeric(model, iter1, iter2, column_id):
 	item2 = model.get_value(iter2, column_id)
 	return cmp(item1, item2)
 
+def gtk_treeview_selection_iterate(treeview):
+	"""
+	Iterate over the a treeview's selected rows.
+
+	:param treeview: The treeview for which to iterate over.
+	:type treeview: :py:class:`Gtk.TreeView`
+	:return: The rows which are selected within the treeview.
+	:rtype: :py:class:`Gtk.TreeIter`
+	"""
+	selection = treeview.get_selection()
+	(model, tree_paths) = selection.get_selected_rows()
+	if not tree_paths:
+		return
+	for tree_path in tree_paths:
+		yield model.get_iter(tree_path)
+
 def gtk_treeview_selection_to_clipboard(treeview, columns=0):
 	"""
 	Copy the currently selected values from the specified columns in the

--- a/king_phisher/client/gui_utilities.py
+++ b/king_phisher/client/gui_utilities.py
@@ -320,7 +320,10 @@ def gtk_treeview_set_column_titles(treeview, column_titles, column_offset=0, ren
 	columns = {}
 	for column_id, column_title in enumerate(column_titles, column_offset):
 		renderer = renderers[column_id - column_offset] if renderers else Gtk.CellRendererText()
-		column = Gtk.TreeViewColumn(column_title, renderer, text=column_id)
+		if isinstance(renderer, Gtk.CellRendererToggle):
+			column = Gtk.TreeViewColumn(column_title, renderer, active=column_id)
+		else:
+			column = Gtk.TreeViewColumn(column_title, renderer, text=column_id)
 		column.set_property('reorderable', True)
 		column.set_sort_column_id(column_id)
 		treeview.append_column(column)

--- a/king_phisher/client/plugins.py
+++ b/king_phisher/client/plugins.py
@@ -35,10 +35,16 @@ import weakref
 from king_phisher import plugins
 
 class ClientPlugin(plugins.PluginBase):
+	"""
+	The base object to be inherited by plugins that are loaded into the King
+	Phisher client. This provides a convenient interface for interacting with
+	the runtime.
+	"""
 	_logging_prefix = 'KingPhisher.Plugins.Client.'
 	def __init__(self, application):
 		super(ClientPlugin, self).__init__()
 		self.application = application
+		"""A reference to the :py:class:`~king_phisher.client.application.KingPhisherClientApplication`."""
 		self._signals = []
 
 	def _cleanup(self):
@@ -51,6 +57,9 @@ class ClientPlugin(plugins.PluginBase):
 
 	@property
 	def config(self):
+		"""
+		A dictionary that can be used by this plugin for persistent storage of it's configuration.
+		"""
 		config = self.application.config['plugins'].get(self.name)
 		if config is None:
 			config = {}
@@ -58,11 +67,30 @@ class ClientPlugin(plugins.PluginBase):
 		return config
 
 	def signal_connect(self, name, handler, gobject=None):
+		"""
+		Connect *handler* to a signal by *name* to an arbitrary GObject. Signals
+		connected through this method are automatically cleaned up when the
+		plugin is disabled. If not GObject is specified, the application is
+		used.
+
+		.. warning::
+			If the signal needs to be disconnected manually by the plugin, this
+			method should not be used. Instead the handler id should be kept as
+			returned by the GObject's native connect method.
+
+		:param str name: The name of the signal.
+		:param handler: The function to be invoked with the signal is emitted.
+		:type handler: function
+		:param gobject: The object to connect the signal to.
+		"""
 		gobject = gobject or self.application
 		handler_id = gobject.connect(name, handler)
 		self._signals.append((weakref.ref(gobject), handler_id))
 
 class ClientPluginManager(plugins.PluginManagerBase):
+	"""
+	The manager for plugins loaded into the King Phisher client application.
+	"""
 	_plugin_klass = ClientPlugin
 	def __init__(self, path, application):
 		super(ClientPluginManager, self).__init__(path, (application,))

--- a/king_phisher/client/plugins.py
+++ b/king_phisher/client/plugins.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+#  king_phisher/client/plugins.py
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following disclaimer
+#    in the documentation and/or other materials provided with the
+#    distribution.
+#  * Neither the name of the project nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+import weakref
+
+from king_phisher import plugins
+
+class ClientPlugin(plugins.PluginBase):
+	_logging_prefix = 'KingPhisher.Plugins.Client.'
+	def __init__(self, application):
+		super(ClientPlugin, self).__init__()
+		self.application = application
+		self._signals = []
+
+	def _cleanup(self):
+		while self._signals:
+			ref, handler_id = self._signals.pop()
+			gobject = ref()
+			if gobject is None:
+				continue
+			gobject.disconnect(handler_id)
+
+	@property
+	def config(self):
+		config = self.application.config['plugins'].get(self.name)
+		if config is None:
+			config = {}
+			self.application.config['plugins'][self.name] = config
+		return config
+
+	def signal_connect(self, name, handler, gobject=None):
+		gobject = gobject or self.application
+		handler_id = gobject.connect(name, handler)
+		self._signals.append((weakref.ref(gobject), handler_id))
+
+class ClientPluginManager(plugins.PluginManagerBase):
+	_plugin_klass = ClientPlugin
+	def __init__(self, path, application):
+		super(ClientPluginManager, self).__init__(path, (application,))

--- a/king_phisher/client/plugins.py
+++ b/king_phisher/client/plugins.py
@@ -37,14 +37,41 @@ from king_phisher import plugins
 from gi.repository import Gtk
 
 class ClientOptionMixin(object):
+	"""
+	A mixin for options used by plugins for the client application. It provides
+	additional methods for creating GTK widgets for the user to set the option's
+	value as well as retrieve it.
+	"""
 	def __init__(self, name, *args, **kwargs):
+		"""
+		:param str name: The name of this option.
+		:param str description: The description of this option.
+		:param default: The default value of this option.
+		:param str display_name: The name to display in the UI to the user for this option.
+		"""
 		self.display_name = kwargs.pop('display_name', name)
 		super(ClientOptionMixin, self).__init__(name, *args, **kwargs)
 
 	def get_widget(self, value):
+		"""
+		Create a widget suitable for configuring this option. This is meant to
+		allow subclasses to specify and create an appropriate widget type.
+
+		:param value: The initial value to set for this widget.
+		:return: The widget for the user to set the option with.
+		:rtype: :py:class:`Gtk.Widget`
+		"""
 		raise NotImplementedError()
 
 	def get_widget_value(self, widget):
+		"""
+		Get the value of a widget previously created with
+		:py:meth:`~.ClientOptionMixin.get_widget`.
+
+		:param widget: The widget from which to retrieve the value from for this option.
+		:type widget: :py:class:`Gtk.Widget`
+		:return: The value for this option as set in the widget.
+		"""
 		raise NotImplementedError()
 
 # base option types
@@ -59,6 +86,13 @@ class ClientOptionBoolean(ClientOptionMixin, plugins.OptionBoolean):
 		return widget.get_active()
 
 class ClientOptionEnum(ClientOptionMixin, plugins.OptionEnum):
+	"""
+	:param str name: The name of this option.
+	:param str description: The description of this option.
+	:param tuple choices: The supported values for this option.
+	:param default: The default value of this option.
+	:param str display_name: The name to display in the UI to the user for this option
+	"""
 	def get_widget(self, value):
 		widget = Gtk.ComboBoxText()
 		widget.set_hexpand(True)

--- a/king_phisher/client/plugins.py
+++ b/king_phisher/client/plugins.py
@@ -47,6 +47,7 @@ class ClientOptionMixin(object):
 	def get_widget_value(self, widget):
 		raise NotImplementedError()
 
+# base option types
 class ClientOptionBoolean(ClientOptionMixin, plugins.OptionBoolean):
 	def get_widget(self, value):
 		widget = Gtk.Switch()
@@ -95,6 +96,8 @@ class ClientOptionString(ClientOptionMixin, plugins.OptionString):
 
 	def get_widget_value(self, widget):
 		return widget.get_text()
+
+# extended option types
 
 class ClientPlugin(plugins.PluginBase):
 	"""

--- a/king_phisher/client/tabs/campaign.py
+++ b/king_phisher/client/tabs/campaign.py
@@ -125,16 +125,15 @@ class CampaignViewGenericTableTab(CampaignViewGenericTab):
 		self.popup_menu = self.treeview_manager.get_popup_menu()
 		"""The :py:class:`Gtk.Menu` object which is displayed when right-clicking in the view area."""
 
-	def _prompt_to_delete_row(self, treeview, selection):
+	def _prompt_to_delete_row(self, treeview, _):
 		if isinstance(self.loader_thread, threading.Thread) and self.loader_thread.is_alive():
 			gui_utilities.show_dialog_warning('Can Not Delete Rows While Loading', self.parent)
 			return
-		(model, tree_paths) = selection.get_selected_rows()
-		if not tree_paths:
+		model = treeview.get_model()
+		row_ids = [model.get_value(ti, 0) for ti in gui_utilities.gtk_treeview_selection_iterate(treeview)]
+		if len(row_ids) == 0:
 			return
-		tree_iters = map(model.get_iter, tree_paths)
-		row_ids = [model.get_value(ti, 0) for ti in tree_iters]
-		if len(row_ids) == 1:
+		elif len(row_ids) == 1:
 			message = 'Delete This Row?'
 		else:
 			message = "Delete These {0:,} Rows?".format(len(row_ids))

--- a/king_phisher/client/windows/main.py
+++ b/king_phisher/client/windows/main.py
@@ -40,6 +40,7 @@ from king_phisher.client import export
 from king_phisher.client import graphs
 from king_phisher.client import gui_utilities
 from king_phisher.client.widget import extras
+from king_phisher.client.windows import plugin_manager
 from king_phisher.client.windows import rpc_terminal
 from king_phisher.client.tabs.campaign import CampaignViewTab
 from king_phisher.client.tabs.campaign import CampaignViewGenericTableTab
@@ -162,6 +163,9 @@ class MainMenuBar(gui_utilities.GladeGObject):
 
 	def do_tools_clone_page(self, _):
 		dialogs.ClonePageDialog(self.application).interact()
+
+	def do_tools_manage_plugins(self, _):
+		plugin_manager.PluginManagerWindow(self.application)
 
 	def do_tools_sftp_client(self, _):
 		self.application.start_sftp_client()

--- a/king_phisher/client/windows/plugin_manager.py
+++ b/king_phisher/client/windows/plugin_manager.py
@@ -38,6 +38,11 @@ from gi.repository import Gtk
 __all__ = ('PluginManagerWindow',)
 
 class PluginManagerWindow(gui_utilities.GladeGObject):
+	"""
+	The window which allows the user to selectively enable and disable plugins
+	for the client application. This also handles configuration changes, so the
+	enabled plugins will persist across application runs.
+	"""
 	dependencies = gui_utilities.GladeDependencies(
 		children=(
 			'treeview_plugins',
@@ -74,6 +79,10 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 		self.window.show()
 
 	def load_plugins(self):
+		"""
+		Load the plugins which are available into the treeview to make them
+		visible to the user.
+		"""
 		store = self._model
 		store.clear()
 		pm = self.application.plugin_manager

--- a/king_phisher/client/windows/plugin_manager.py
+++ b/king_phisher/client/windows/plugin_manager.py
@@ -50,6 +50,7 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 		children=(
 			'expander_plugin_info',
 			'label_plugin_info_authors',
+			'label_plugin_info_compatible',
 			'label_plugin_info_description',
 			'label_plugin_info_homepage',
 			'label_plugin_info_title',
@@ -128,6 +129,9 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 			self._model[path][1] = False
 			self.config['plugins.enabled'].remove(name)
 		else:
+			if not pm.loaded_plugins[name].is_compatible:
+				gui_utilities.show_dialog_error('Incompatible Plugin', self.window, 'This plugin is not compatible.')
+				return
 			if not pm.enable(name):
 				return
 			self._model[path][1] = True
@@ -142,8 +146,9 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 		name = self._model[path][0]
 		klass = pm.loaded_plugins[name]
 		self.gobjects['label_plugin_info_title'].set_text(klass.title)
-		self.gobjects['label_plugin_info_authors'].set_text('\n'.join(klass.authors))
+		self.gobjects['label_plugin_info_compatible'].set_text('Yes' if klass.is_compatible else 'No')
 		self.gobjects['label_plugin_info_version'].set_text(klass.version)
+		self.gobjects['label_plugin_info_authors'].set_text('\n'.join(klass.authors))
 		label_homepage = self.gobjects['label_plugin_info_homepage']
 		if klass.homepage is None:
 			label_homepage.set_property('visible', False)

--- a/king_phisher/client/windows/plugin_manager.py
+++ b/king_phisher/client/windows/plugin_manager.py
@@ -32,6 +32,7 @@
 
 import textwrap
 
+from king_phisher import utilities
 from king_phisher.client import gui_utilities
 from king_phisher.client.widget import managers
 
@@ -50,6 +51,7 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 			'expander_plugin_info',
 			'label_plugin_info_authors',
 			'label_plugin_info_description',
+			'label_plugin_info_homepage',
 			'label_plugin_info_title',
 			'label_plugin_info_version',
 			'treeview_plugins',
@@ -102,6 +104,9 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 				plugin.title
 			))
 
+	def signal_label_activate_link(self, _, uri):
+		utilities.open_uri(uri)
+
 	def signal_popup_menu_activate_reload(self, _):
 		treeview = self.gobjects['treeview_plugins']
 		pm = self.application.plugin_manager
@@ -138,6 +143,12 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 		self.gobjects['label_plugin_info_title'].set_text(klass.title)
 		self.gobjects['label_plugin_info_authors'].set_text('\n'.join(klass.authors))
 		self.gobjects['label_plugin_info_version'].set_text(klass.version)
+		label_homepage = self.gobjects['label_plugin_info_homepage']
+		if klass.homepage is None:
+			label_homepage.set_property('visible', False)
+		else:
+			label_homepage.set_markup("<a href=\"{0}\">Homepage</a>".format(klass.homepage))
+			label_homepage.set_property('visible', True)
 		description = klass.description
 		if description[0] == '\n':
 			description = description[1:]

--- a/king_phisher/client/windows/plugin_manager.py
+++ b/king_phisher/client/windows/plugin_manager.py
@@ -128,7 +128,8 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 			self._model[path][1] = False
 			self.config['plugins.enabled'].remove(name)
 		else:
-			pm.enable(name)
+			if not pm.enable(name):
+				return
 			self._model[path][1] = True
 			self.config['plugins.enabled'].append(name)
 

--- a/king_phisher/client/windows/plugin_manager.py
+++ b/king_phisher/client/windows/plugin_manager.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+#  king_phisher/client/windows/plugin_manager.py
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following disclaimer
+#    in the documentation and/or other materials provided with the
+#    distribution.
+#  * Neither the name of the project nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+from king_phisher.client import gui_utilities
+from king_phisher.client.widget import managers
+
+from gi.repository import Gtk
+
+__all__ = ('PluginManagerWindow',)
+
+class PluginManagerWindow(gui_utilities.GladeGObject):
+	dependencies = gui_utilities.GladeDependencies(
+		children=(
+			'treeview_plugins',
+		)
+	)
+	top_gobject = 'window'
+	def __init__(self, *args, **kwargs):
+		super(PluginManagerWindow, self).__init__(*args, **kwargs)
+		treeview = self.gobjects['treeview_plugins']
+		self.treeview_manager = managers.TreeViewManager(treeview, cb_refresh=self.load_plugins)
+		toggle_renderer = Gtk.CellRendererToggle()
+		toggle_renderer.connect('toggled', self.signal_renderer_toggled)
+		self.treeview_manager.set_column_titles(
+			('Enabled', 'Plugin'),
+			column_offset=1,
+			renderers=(toggle_renderer, Gtk.CellRendererText())
+		)
+		self._model = Gtk.ListStore(str, bool, str)
+		self._model.set_sort_column_id(2, Gtk.SortType.DESCENDING)
+		treeview.set_model(self._model)
+		self.load_plugins()
+		self.window.show()
+
+	def load_plugins(self):
+		store = self._model
+		store.clear()
+		pm = self.application.plugin_manager
+		pm.load_all()
+		for plugin in pm.loaded_plugins.values():
+			store.append((
+				plugin.name,
+				plugin.name in pm.enabled_plugins,
+				plugin.title
+			))
+
+	def signal_renderer_toggled(self, _, path):
+		pm = self.application.plugin_manager
+		name = self._model[path][0]
+		if self._model[path][1]:
+			pm.disable(name)
+			self._model[path][1] = False
+			self.config['plugins.enabled'].remove(name)
+		else:
+			pm.enable(name)
+			self._model[path][1] = True
+			self.config['plugins.enabled'].append(name)

--- a/king_phisher/errors.py
+++ b/king_phisher/errors.py
@@ -35,7 +35,9 @@ class KingPhisherError(Exception):
 	The base exception that is inherited by all custom King Phisher error
 	classes.
 	"""
-	pass
+	def __init__(self, message=''):
+		super(KingPhisherError, self).__init__()
+		self.message = message
 
 class KingPhisherAbortError(KingPhisherError):
 	"""

--- a/king_phisher/errors.py
+++ b/king_phisher/errors.py
@@ -78,6 +78,13 @@ class KingPhisherPermissionError(KingPhisherError):
 	"""
 	pass
 
+class KingPhisherResourceError(KingPhisherError):
+	"""
+	An exception that is raised by King Phisher when there is a problem relating
+	to a resource such as it is missing, locked or otherwise invalid.
+	"""
+	pass
+
 class KingPhisherTimeoutError(KingPhisherError):
 	"""
 	An exception that is raised by King Phisher when some form of a request

--- a/king_phisher/plugins.py
+++ b/king_phisher/plugins.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+#  king_phisher/plugins.py
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following disclaimer
+#    in the documentation and/or other materials provided with the
+#    distribution.
+#  * Neither the name of the project nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+import logging
+import threading
+
+import pluginbase
+
+class PluginBase(object):
+	authors = []
+	title = None
+	description = None
+	_logging_prefix = 'KingPhisher.Plugins.'
+	def __init__(self):
+		self.logger = logging.getLogger(self._logging_prefix + self.__class__.__name__)
+
+	def _cleanup(self):
+		pass
+
+	def finalize(self):
+		pass
+
+	def initialize(self):
+		pass
+
+class PluginManagerBase(object):
+	_plugin_klass = PluginBase
+	def __init__(self, path, args=None):
+		self._lock = threading.RLock()
+		self.plugin_init_args = (args or ())
+		self.plugin_base = pluginbase.PluginBase(package='king_phisher.plugins.loaded')
+		self.plugin_source = self.plugin_base.make_plugin_source(searchpath=path)
+		self.loaded_plugins = {}
+		self.enabled_plugins = {}
+		self.logger = logging.getLogger('KingPhisher.Plugins.Manager')
+		self.load_all()
+
+	def __contains__(self, key):
+		return key in self.loaded_plugins
+
+	def __getitem__(self, key):
+		return self.loaded_plugins[key]
+
+	def __delitem__(self, key):
+		self.unload(key)
+
+	def __iter__(self):
+		for name, inst in self.loaded_plugins.items():
+			yield name, inst
+
+	def __len__(self):
+		return len(self.loaded_plugins)
+
+	@property
+	def available(self):
+		return self.plugin_source.list_plugins()
+
+	def shutdown(self):
+		self.unload_all()
+		self.plugin_source.cleanup()
+
+	# methods to deal with plugin enable operations
+	def enable(self, name):
+		self._lock.acquire()
+		klass = self.loaded_plugins.get(name, None)
+		if klass is None:
+			klass = self.load(name)
+		inst = klass(*self.plugin_init_args)
+		self.enabled_plugins[name] = inst
+		self._lock.release()
+		inst.initialize()
+		return inst
+
+	def disable(self, name):
+		self._lock.acquire()
+		inst = self.enabled_plugins[name]
+		inst.finalize()
+		inst._cleanup()
+		del self.enabled_plugins[name]
+		self._lock.release()
+
+	# methods to deal with plugin load operations
+	def load(self, name):
+		self._lock.acquire()
+		module = self.plugin_source.load_plugin(name)
+		klass = getattr(module, 'Plugin', None)
+		if klass is None:
+			self._lock.release()
+			raise Exception
+		if not issubclass(klass, self._plugin_klass):
+			self._lock.release()
+			raise Exception
+		klass.name = name
+		self.loaded_plugins[name] = klass
+		self.logger.debug("plugin '{0}' has been loaded".format(name))
+		self._lock.release()
+		return klass
+
+	def load_all(self):
+		self._lock.acquire()
+		plugins = self.plugin_source.list_plugins()
+		self.logger.info("loading {0:,} plugins".format(len(plugins)))
+		for name in plugins:
+			self.load(name)
+		self._lock.release()
+
+	def unload(self, name):
+		self._lock.acquire()
+		if name in self.enabled_plugins:
+			self.disable(name)
+		del self.loaded_plugins[name]
+		self.logger.debug("plugin '{0}' has been unloaded".format(name))
+		self._lock.release()
+
+	def unload_all(self):
+		self._lock.acquire()
+		self.logger.info("unloading {0:,} plugins".format(len(self.loaded_plugins)))
+		for name in tuple(self.loaded_plugins.keys()):
+			self.unload(name)
+		self._lock.release()

--- a/king_phisher/plugins.py
+++ b/king_phisher/plugins.py
@@ -147,8 +147,11 @@ class PluginBase(PluginBaseMeta('PluginBaseMeta', (object,), {})):
 		This method should be overridden to provide the primary functionality of
 		the plugin. It is called automatically by the manager when the plugin is
 		enabled.
+
+		:return: Whether or not the plugin successfully initialized itself.
+		:rtype: bool
 		"""
-		pass
+		return True
 
 class PluginManagerBase(object):
 	"""
@@ -216,9 +219,11 @@ class PluginManagerBase(object):
 		if not klass.is_compatible:
 			raise errors.KingPhisherError('this plugin is incompatible')
 		inst = klass(*self.plugin_init_args)
+		if not inst.initialize():
+			self._lock.release()
+			return
 		self.enabled_plugins[name] = inst
 		self._lock.release()
-		inst.initialize()
 		return inst
 
 	def disable(self, name):

--- a/king_phisher/plugins.py
+++ b/king_phisher/plugins.py
@@ -292,7 +292,7 @@ class PluginManagerBase(object):
 			self.logger.warning("failed to load plugin '{0}', Plugin class is invalid".format(name))
 			raise errors.KingPhisherResourceError('the Plugin class is invalid')
 		self.loaded_plugins[name] = klass
-		self.logger.debug("plugin '{0}' has been loaded".format(name))
+		self.logger.debug("plugin '{0}' has been {1}loaded".format(name, 're' if reload_module else ''))
 		self._lock.release()
 		return klass
 

--- a/king_phisher/plugins.py
+++ b/king_phisher/plugins.py
@@ -103,7 +103,6 @@ class PluginManagerBase(object):
 		self.enabled_plugins = {}
 		"""A dictionary of the enabled plugins and their respective instances."""
 		self.logger = logging.getLogger('KingPhisher.Plugins.Manager')
-		self.load_all()
 
 	def __contains__(self, key):
 		return key in self.loaded_plugins

--- a/king_phisher/plugins.py
+++ b/king_phisher/plugins.py
@@ -49,25 +49,43 @@ else:
 StrictVersion = distutils.version.StrictVersion
 
 class OptionBase(object):
+	"""
+	A base class for options which can be configured for plugins.
+	"""
 	_type = (unicode if its.py_v2 else str)
 	def __init__(self, name, description, default=None):
+		"""
+		:param str name: The name of this option.
+		:param str description: The description of this option.
+		:param default: The default value of this option.
+		"""
 		self.name = name
 		self.description = description
 		self.default = default
 
 class OptionBoolean(OptionBase):
+	"""A plugin option which is represented with a boolean value."""
 	_type = bool
 
 class OptionEnum(OptionBase):
+	"""A plugin option which is represented with an enumerable value."""
 	_type = str
 	def __init__(self, name, description, choices, default=None):
+		"""
+		:param str name: The name of this option.
+		:param str description: The description of this option.
+		:param tuple choices: The supported values for this option.
+		:param default: The default value of this option.
+		"""
 		self.choices = choices
 		super(OptionEnum, self).__init__(name, description, default=default)
 
 class OptionInteger(OptionBase):
+	"""A plugin option which is represented with an integer value."""
 	_type = int
 
 class OptionString(OptionBase):
+	"""A plugin option which is represented with a string value."""
 	pass
 
 class PluginBaseMeta(type):

--- a/king_phisher/plugins.py
+++ b/king_phisher/plugins.py
@@ -57,6 +57,10 @@ class PluginBase(object):
 	"""The title of the plugin."""
 	description = None
 	"""A description of the plugin and what it does."""
+	homepage = None
+	"""An optional homepage for the plugin."""
+	version = '1.0'
+	"""The version identifier of this plugin."""
 	_logging_prefix = 'KingPhisher.Plugins.'
 	def __init__(self):
 		self.logger = logging.getLogger(self._logging_prefix + self.__class__.__name__)

--- a/king_phisher/smtp_server.py
+++ b/king_phisher/smtp_server.py
@@ -53,7 +53,7 @@ class BaseSMTPServer(smtpd.SMTPServer, object):
 
 	def serve_forever(self):
 		"""
-		Process requests until a :py:meth:`.shutdown` is called.
+		Process requests until a :py:meth:`BaseSMTPServer.shutdown` is called.
 		"""
 		asyncore.loop()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ markupsafe>=0.23
 matplotlib>=1.5.1
 msgpack-python>=0.4.7
 paramiko>=1.16.0
+pluginbase>=0.3
 psycopg2>=2.6.1
 pyotp>=2.0.1
 python-dateutil>=2.5.1


### PR DESCRIPTION
This PR adds plugin support to the client and lays the ground work for plugins to be included in the server. There is not much of a "plugin API" yet, really there's only two convenience features supported by the `ClientPlugin` class:
 - Dedicated persistent configuration storage
 - Easy GTK signal connections with automatic removal when plugins are disabled

Client plugins are currently loaded from two locations:
 - `data/client/king_phisher/plugins` For plugins distributed by us as part of the project
 - `~/.config/king-phisher/plugins` For user-specific plugins

Plugins have a couple of states:
 - **Unloaded** The plugin exists on disk but has not been imported by Python into the process
 - **Loaded** The plugin has been imported by Python so the metadata can be accessed from the `Plugin` class
 - **Enabled** The plugin class has been initialized and is doing things

Right now the client "loads" all plugins on start up to allow the metadata to be accessed.

Testing:
 - [x] Review the basic API in `king_phisher/plugins.py` makes sense (it'll be used be the server too eventually)
 - [x] Build and read the docs
 - [x] Test the plugin manager in the GUI `Tools > Plugin Manager`
  - [x] Enabling plugins should work
  - [x] Disabling plugins should work
  - [x] Enabled plugins should persist across application runs
  - [x] Plugins meta data should be displayed in the manager
 - [x] The `--no-plugins` option disables all plugins on start up (to avoid any potential issues)

Here is a Hello World plugin suitable for testing. Once this is landed it will be included in the docs, pending any API changes that this PR review brings up.
```python
import king_phisher.client.plugins as plugins
import king_phisher.client.gui_utilities as gui_utilities

class Plugin(plugins.ClientPlugin):
	authors = ['Spencer McIntyre']
	title = 'Hello World!'
	description = 'A test plugin.'
	homepage = 'https://github.com/securestate/king-phisher'
	def initialize(self):
		print('Hello World!')
		self.signal_connect('exit', self.signal_exit)

	def finalize(self):
		print('Good Bye World!')

	def signal_exit(self, app):
		gui_utilities.show_dialog_info('Exiting!', app.get_active_window())
```