### PR TITLE
Stop Loading Campaign Data When It Changes

### DIFF
--- a/king_phisher/client/tabs/campaign.py
+++ b/king_phisher/client/tabs/campaign.py
@@ -417,6 +417,7 @@ class CampaignViewDashboardTab(CampaignViewGenericTab):
 			return
 		with self.loader_thread_lock:
 			self._sync_loader_thread()
+			self.loader_thread_stop.clear()
 			self.loader_thread = threading.Thread(target=self.loader_thread_routine)
 			self.loader_thread.daemon = True
 			self.loader_thread.start()


### PR DESCRIPTION
This changes the behavior of the loader threads responsible for loading the data seen in the Campaign tab. When the campaign-set signal is emitted, each of these threads spin up to refresh their respective views. Prior to this change, if the thread was busy while this signal was emitted, the load operation would simply be skipped. This changes that behavior to using a new `threading.Event` to signal that the thread loader should stop what it's doing. This is then used to stop threads which may be loading old campaign data to allow them to be restarted to load the new campaigns data. This issue can be encountered when opening a large campaign (think 10k+ messages) and then changing the campaign while the previous campaigns data was still being loaded.

Verification steps:
 - [x] Load a large campaign
 - [x] Immediately load a smaller campaign (while data from the first is still being loaded)
 - [x] See the data from the large campaign *immediately* stop loading as the new data starts
 - [x] Ensure campaigns can be changed to and from as would normally be expected

CC: @guitarmanj