### PR TITLE
Updates to support Fedora 23

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -251,7 +251,8 @@ if [ "$LINUX_VERSION" == "CentOS" ]; then
 	fi
 elif [ "$LINUX_VERSION" == "Fedora" ]; then
 	dnf install -y freetype-devel gcc gcc-c++ gtk3-devel \
-		libpng-devel postgresql-devel python-devel python-pip
+		libpng-devel postgresql-devel python-devel python-pip \
+		libffi-devel openssl-devel
 	if [ -z "$KING_PHISHER_SKIP_CLIENT" ]; then
 		dnf install -y geos geos-devel gtksourceview3 vte3
 	fi


### PR DESCRIPTION
@zeroSteiner 

Updated install.sh to provide missing libs required to compile python pip installs on Fedora 23.

libffi-devel for cffi
openssl-devel for crypto library requirement for paramiko.

- [ ] King Phisher correctly installs on a fresh install of Fedora 23