### PR TITLE
Python3 install

### DIFF
--- a/data/client/king-phisher.desktop
+++ b/data/client/king-phisher.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=King Phisher
 GenericName=King Phisher
-Exec=python /opt/king-phisher/KingPhisher
+Exec=/usr/bin/python3 /opt/king-phisher/KingPhisher
 Terminal=false
 Type=Application
 Categories=Network;Security;

--- a/data/server/service_files/king-phisher.conf
+++ b/data/server/service_files/king-phisher.conf
@@ -7,6 +7,4 @@ start on runlevel [2345]
 stop on runlevel [!2345]
 
 # Installed Together In /opt/king-phisher
-# exec /opt/king-phisher/KingPhisherServer -f /opt/king-phisher/server_config.yml
-# Installed With 'python server-setup.py install'
-exec KingPhisherServer -f /etc/king-phisher.yml
+exec /usr/bin/python3 /opt/king-phisher/KingPhisherServer -f /opt/king-phisher/server_config.yml

--- a/data/server/service_files/king-phisher.service
+++ b/data/server/service_files/king-phisher.service
@@ -9,9 +9,7 @@ After=syslog.target network.target auditd.service
 Type=forking
 PIDFile=/var/run/king-phisher.pid
 # Installed Together In /opt/king-phisher
-# ExecStart=/opt/king-phisher/KingPhisherServer /opt/king-phisher/server_config.yml
-# Installed With 'python server-setup.py install'
-ExecStart=KingPhisherServer /etc/king-phisher.yml
+ExecStart=/usr/bin/python3 /opt/king-phisher/KingPhisherServer /opt/king-phisher/server_config.yml
 ExecStop=/bin/kill -INT $MAINPID
 
 [Install]

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -428,11 +428,13 @@ if [ -z "$KING_PHISHER_SKIP_SERVER" ]; then
 		echo "Starting the King Phisher service"
 		start king-phisher
 	else
-		echo "Start the King Phisher server with the following command: "
+		echo "-----------------------------------------------------------------------------------------------"
+		echo "Start the King Phisher server with the following command prior to starting the client: "
 		echo "sudo python3 $KING_PHISHER_DIR/KingPhisherServer -L INFO -f $KING_PHISHER_DIR/server_config.yml"
 	fi
 fi
 if [ -z "$KING_PHISHER_SKIP_CLIENT" ]; then
-    echo "You Can start King Phisher Client with the following command: "
-    echo "python3 $KING_PHISHER_DIR/KingPhisher"
+	echo "-----------------------------------------------------------------------------------------------"
+	echo "You can start King Phisher client with the following command: "
+	echo "python3 $KING_PHISHER_DIR/KingPhisher"
 fi


### PR DESCRIPTION
Updated the tools/install.sh and service files.

- Updated the install.sh script to only install python3 requirements for King Phisher.
- Updated King Phisher Server service files (.conf and .service) to utilize python3
- Updated King Phisher Client desktop icon to utilize python3
- Updated the install script to initialize postgresql database, if postgresql fails to start during King Phisher server installation.
- Updated the install script to insert the king phisher entry into the postgres's hba_file in the local connection area.
- Updated install script output to reflect to start King Phisher Server and Client with python3.

To test utilize the tools/install.sh script to install King Phisher and verify the King Phisher Server and King Phisher Client successfully runs in python3.
- [ ] Installs and runs on Ubuntu Gnome
- [ ] Installs and runs on Fedora 23-24
- [ ] Installs and runs on Backbox
- [ ] Installs and runs on Debian with Gnome installation
- [ ] Installs and runs on kali linux rolling
- [ ] tools/install.sh script correctly details how to launch King Phisher client and Server
