### PR TITLE
updated cx_freeze for windows build

### DIFF
--- a/tools/cx_freeze.py
+++ b/tools/cx_freeze.py
@@ -136,7 +136,9 @@ build_exe_options = dict(
 	include_files=include_files,
 	packages=[
 		'cairo',
-		'Crypto',
+		'cffi',             # cryptography requirement
+		'cryptography',     # paramiko requirement
+		'OpenSSL',          # cryptography backends
 		'email',
 		'gi',
 		'jinja2',


### PR DESCRIPTION
Updated for version 1.4 for paramiko 2.0 and above utilizing cryptography