### PR TITLE
Close the websocket on RPC logout

### DIFF
--- a/king_phisher/client/server_events.py
+++ b/king_phisher/client/server_events.py
@@ -90,6 +90,8 @@ class ServerEventSubscriber(_GObject_GObject):
 		self.__is_shutdown = threading.Event()
 		self.__is_shutdown.clear()
 		self._reconnect_event_id = None
+		self.reconnect = True
+		"""Whether or not the socket should attempt to reconnect itself when it has been closed."""
 		self.rpc = rpc
 		self._connect_event = threading.Event()
 		self._subscriptions = collections.defaultdict(lambda: collections.defaultdict(int))
@@ -100,13 +102,15 @@ class ServerEventSubscriber(_GObject_GObject):
 	def _on_close(self, _):
 		if self._worker_thread is None:  # the socket was never successfully opened
 			return
-		self.logger.warning('the server event socket has been closed')
+		getattr(self.logger, 'warning' if self.reconnect else 'info')('the server event socket has been closed')
 		self._connect_event.clear()
 		if self.__is_shutdown.is_set():
 			return
 		if self._worker_thread != threading.current_thread():
 			return
 		self._worker_thread = None
+		if not self.reconnect:
+			return
 		self._reconnect_event_id = GLib.timeout_add_seconds(30, self._ws_reconnect)
 
 	def _on_message(self, _, message):
@@ -155,6 +159,7 @@ class ServerEventSubscriber(_GObject_GObject):
 			on_open=self._on_open
 		)
 		new_thread = threading.Thread(target=self.ws.run_forever, kwargs={'sslopt': {'cert_reqs': ssl.CERT_NONE}})
+		new_thread.daemon = True
 		new_thread.start()
 		if not self._connect_event.wait(10):
 			self.logger.error('failed to connect to the server event socket')
@@ -187,10 +192,15 @@ class ServerEventSubscriber(_GObject_GObject):
 		"""
 		Disconnect the event socket from the remote server. After the object is
 		shutdown, remove events will no longer be published.
+
+		:param int timeout: An optional timeout for how long to wait on the worker thread.
 		"""
 		self.__is_shutdown.set()
-		self.ws.close()
-		self._worker_thread.join()
+		self.logger.debug('shutting down the server event socket')
+		worker = self._worker_thread
+		if worker:
+			worker.join()
+			self._worker_thread = None
 
 	def _subscribe(self, event_id, event_types, attributes):
 		# same as subscribe but without reference counting

--- a/king_phisher/server/build.py
+++ b/king_phisher/server/build.py
@@ -77,9 +77,9 @@ def get_bind_addresses(config):
 
 	for host, port, use_ssl in addresses:
 		if port in (443, 8443) and not use_ssl:
-			logger.warning("running on port {0} without ssl, specify server.ssl_cert to enable ssl".format(port))
+			logger.warning("running on port {0} without ssl, this is generally unintended behaviour".format(port))
 		elif port in (80, 8080) and use_ssl:
-			logger.warning("running on port {0} with ssl, remove server.ssl_cert to disable ssl".format(port))
+			logger.warning("running on port {0} with ssl, this is generally unintended behaviour".format(port))
 	return addresses
 
 def get_ssl_hostnames(config):

--- a/king_phisher/server/server_rpc.py
+++ b/king_phisher/server/server_rpc.py
@@ -672,11 +672,13 @@ def rpc_login(handler, session, username, password, otp=None):
 
 @register_rpc('/logout', log_call=True)
 def rpc_logout(handler):
-	username = handler.rpc_session.user
+	rpc_session = handler.rpc_session
+	if rpc_session.event_socket is not None:
+		rpc_session.event_socket.close()
 	handler.server.session_manager.remove(handler.rpc_session_id)
 	logger = logging.getLogger('KingPhisher.Server.Authentication')
-	logger.info("successful logout request from {0} for user {1}".format(handler.client_address[0], username))
-	signals.rpc_user_logged_out.send(handler, session=handler.rpc_session_id, name=username)
+	logger.info("successful logout request from {0} for user {1}".format(handler.client_address[0], rpc_session.user))
+	signals.rpc_user_logged_out.send(handler, session=handler.rpc_session_id, name=rpc_session.user)
 
 @register_rpc('/plugins/list', log_call=True)
 def rpc_plugins_list(handler):


### PR DESCRIPTION
This PR changes how the client shutsdown the web socket. Instead of closing it on the client side and waiting for the event loop to exit out, the client lets the server shut it down as part of the logout process. This means that the connection close is initiated from the server side instead of the client. This seems to allow the `run_forever` loop to process the servers close message and exit correctly. There's an internal flag `reconnect` that just needs to be set to False letting the event socket know that we're done with it and it doesn't need to try and reconnect to the server.

The server should have been shutting down the event socket if it existed when the client logged out anyways.

- [x] Test that this fixes the periodic logout hang when the client goes to exit the application

There is another `ConnectionResetError` exception that sometimes get's raised. That's a separate issue that is less of a concern because the client can still exit instead of hanging indefinitely. That issue can be tracked with the KP-45 ticket. Disregard that for now, I'll fix it next.