### PR TITLE
Corrected unicode and utf8 issue

### DIFF
--- a/king_phisher/client/application.py
+++ b/king_phisher/client/application.py
@@ -367,7 +367,7 @@ class KingPhisherClientApplication(_Gtk_Application):
 				)
 
 	def do_campaign_set(self, campaign_id):
-		self.logger.info("campaign set to {0} (id: {1})".format(self.config['campaign_name'], self.config['campaign_id']))
+		self.logger.info("campaign set to {0} (id: {1})".format(self.config['campaign_name'].encode('utf-8'), self.config['campaign_id']))
 		self.emit('rpc-cache-clear')
 
 	def do_config_save(self):

--- a/king_phisher/client/tabs/campaign.py
+++ b/king_phisher/client/tabs/campaign.py
@@ -202,8 +202,6 @@ class CampaignViewGenericTableTab(CampaignViewGenericTab):
 		elif cell_data is None:
 			return ''
 
-		if isinstance(cell_data, bytes):
-			cell_data = cell_data.decode('utf-8')
 		return cell_data
 
 	def load_campaign_information(self, force=True):

--- a/king_phisher/client/tabs/campaign.py
+++ b/king_phisher/client/tabs/campaign.py
@@ -201,7 +201,10 @@ class CampaignViewGenericTableTab(CampaignViewGenericTab):
 			return utilities.format_datetime(cell_data)
 		elif cell_data is None:
 			return ''
-		return str(cell_data)
+
+		if isinstance(cell_data, bytes):
+			cell_data = cell_data.decode('utf-8')
+		return cell_data
 
 	def load_campaign_information(self, force=True):
 		"""


### PR DESCRIPTION
This is to correct the issue #169. As information is being loaded into the GTK-TreeView(s) it will check to see if that cell of information is in `bytes` and if so it will decode it to `utf-8`. By doing this the windows application that is running python2 will now properly display special characters. 

To test, Follow instructions from #169 in a windows client, or running King Phisher in python2. Special characters such as `ąćęłńóśżź` should now correctly display in the department field.

Create a new campaign with special characters. It should correctly populate with out a stack trace.

- [x] Department field now displays special characters
- [ ] Campaign Names now can have special characters
