### PR TITLE
RPC insert multi

### DIFF
--- a/king_phisher/client/mailer.py
+++ b/king_phisher/client/mailer.py
@@ -80,7 +80,6 @@ __all__ = (
 	'render_message_template'
 )
 
-make_uid = lambda: utilities.random_string(16)
 template_environment = templates.MessageTemplateEnvironment()
 
 MessageAttachments = collections.namedtuple('MessageAttachments', ('files', 'images'))
@@ -127,7 +126,7 @@ def render_message_template(template, config, target=None, analyze=False):
 			last_name='Liddle',
 			email_address='aliddle@wonderland.com',
 			department=None,
-			uid=(config['server_config'].get('server.secret_id') or make_uid())
+			uid=(config['server_config'].get('server.secret_id') or utilities.make_message_uid())
 		)
 		template_environment.set_mode(template_environment.MODE_PREVIEW)
 
@@ -460,7 +459,7 @@ class MailSenderThread(threading.Thread):
 				last_name=target_name[1].strip(),
 				email_address=self.config['mailer.target_email_address'],
 				department=None,
-				uid=make_uid()
+				uid=utilities.make_message_uid()
 			)
 			yield target
 		elif target_type == 'file':
@@ -491,7 +490,7 @@ class MailSenderThread(threading.Thread):
 					last_name=raw_target['last_name'].strip(),
 					email_address=email_address,
 					department=department,
-					uid=make_uid(),
+					uid=utilities.make_message_uid(),
 					line=line_no
 				)
 				if not target.email_address:

--- a/king_phisher/server/server.py
+++ b/king_phisher/server/server.py
@@ -678,7 +678,7 @@ class KingPhisherRequestHandler(advancedhttpserver.RequestHandler):
 					visit_id = None
 
 		if visit_id is None:
-			visit_id = make_visit_uid()
+			visit_id = utilities.make_visit_uid()
 
 		if set_new_visit:
 			kp_cookie_name = self.config.get('server.cookie_name')

--- a/king_phisher/server/server.py
+++ b/king_phisher/server/server.py
@@ -59,7 +59,6 @@ import advancedhttpserver
 import jinja2
 from smoke_zephyr import job
 
-make_uid = lambda: utilities.random_string(24)
 
 class KingPhisherRequestHandler(advancedhttpserver.RequestHandler):
 	logger = logging.getLogger('KingPhisher.Server.RequestHandler')
@@ -679,7 +678,7 @@ class KingPhisherRequestHandler(advancedhttpserver.RequestHandler):
 					visit_id = None
 
 		if visit_id is None:
-			visit_id = make_uid()
+			visit_id = make_visit_uid()
 
 		if set_new_visit:
 			kp_cookie_name = self.config.get('server.cookie_name')

--- a/king_phisher/utilities.py
+++ b/king_phisher/utilities.py
@@ -53,6 +53,8 @@ from smoke_zephyr.utilities import which
 
 EMAIL_REGEX = re.compile(r'^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,7}$', flags=re.IGNORECASE)
 TIMESTAMP_FORMAT = '%Y-%m-%d %H:%M:%S'
+make_message_uid = lambda: random_string(16)
+make_visit_uid = lambda: random_string(24)
 
 class FreezableDict(collections.OrderedDict):
 	"""
@@ -324,7 +326,6 @@ def password_is_complex(password, min_len=12):
 	"""
 	Check that the specified string meets standard password complexity
 	requirements.
-	
 	:param str password: The password to validate.
 	:param int min_len: The mininum length the password should be.
 	:return: Whether the strings appears to be complex or not.

--- a/king_phisher/utilities.py
+++ b/king_phisher/utilities.py
@@ -53,8 +53,6 @@ from smoke_zephyr.utilities import which
 
 EMAIL_REGEX = re.compile(r'^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,7}$', flags=re.IGNORECASE)
 TIMESTAMP_FORMAT = '%Y-%m-%d %H:%M:%S'
-make_message_uid = lambda: random_string(16)
-make_visit_uid = lambda: random_string(24)
 
 class FreezableDict(collections.OrderedDict):
 	"""
@@ -346,6 +344,24 @@ def password_is_complex(password, min_len=12):
 		if has_upper and has_lower and has_digit:
 			return True
 	return False
+
+def make_message_uid():
+	"""
+	Creates a random string of 16 characters and numbers to be used as a message id.
+
+	:return: String of 16 characters from the random_string function
+	:rtype: str
+	"""
+	return random_string(16)
+
+def make_visit_uid():
+	"""
+	Creates a random string of 24 characters and number to be used as a visit id.
+
+	:return: String of 24 characters
+	:rtype: str
+	"""
+	return random_string(24)
 
 def random_string(size):
 	"""


### PR DESCRIPTION
This PR will add RPC `/db/table/insert/multi` functionality to insert multiple rows in to a database. Additionally if `deconflict_ids` is true to will generate new ID to add that row into the database. To support this `make_uid` functionality for messages and visits have been moved to `utilities.py` to allow both client and server access to these functions. 

- [x] Function description for `/db/table/insert/multi` makes since

Testing:
- [x] Pull down PR and start King Phisher server and Client utilizing new library
- [x] Run a test campaign to verify message uids are being generated correctly
- [x] Visit pages from test campaign to verify visit uids are being generated corrrectly
- [x] Start RPC Terminal in King Phisher Client
- [x] use rpc.('/db/table/insert/multi', str(table_name), list(keys), list((values,), (values,))) to insert multiple rows with specified values into target table.
-  [x] use rpc.('/db/table/insert/multi', str(table_name), list(keys), list((values,), (values,)), deconflict_ids=True) to insert multiple rows with specified values into target table and and deconflict ids of rows.