### PR TITLE
Support Serializing Values To XML Elements

### DIFF
--- a/docs/source/king_phisher/serializers.rst
+++ b/docs/source/king_phisher/serializers.rst
@@ -13,6 +13,8 @@ of them.
 Functions
 ---------
 
+.. autofunction:: king_phisher.serializers.from_elementtree_element
+
 .. autofunction:: king_phisher.serializers.to_elementtree_subelement
 
 Classes

--- a/docs/source/king_phisher/serializers.rst
+++ b/docs/source/king_phisher/serializers.rst
@@ -10,6 +10,11 @@ their format into different classes. The necessary methods for utilizing them
 are all ``classmethod``'s making it unnecessary to create an instance of any
 of them.
 
+Functions
+---------
+
+.. autofunction:: king_phisher.serializers.to_elementtree_subelement
+
 Classes
 -------
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -44,6 +44,7 @@ from .geoip import GeoIPTests
 from .geoip import GeoIPRPCTests
 from .ics import ICSTests
 from .ipaddress import IPAddressTests
+from .serializers import ElementTreeTests
 from .serializers import JsonSerializerTests
 from .serializers import MsgPackSerializerTests
 from .sms import SMSTests

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -31,6 +31,7 @@
 #
 
 import datetime
+import xml.etree.ElementTree as ET
 
 from king_phisher import testing
 from king_phisher import serializers
@@ -58,6 +59,20 @@ class _SerializerTests(testing.KingPhisherServerTestCase):
 		self.assertNotEqual(type(now), type(serialized))
 		now_loaded = self.serializer.loads(serialized)
 		self.assertEqual(now, now_loaded)
+
+class _ElementTreeSerializer(object):
+	# this class defines a pseudo serializer that allows the functions to be
+	# tested in the same way as the serializers that are implemented as classes
+	def dumps(self, value):
+		parent = ET.Element('parent')
+		return serializers.to_elementtree_subelement(parent, 'child', value)
+
+	def loads(self, element):
+		return serializers.from_elementtree_element(element)
+
+class ElementTreeTests(_SerializerTests):
+	serializer = _ElementTreeSerializer()
+	serializer_output_type = ET.Element
 
 class JsonSerializerTests(_SerializerTests):
 	serializer = serializers.JSON


### PR DESCRIPTION
This pull requests adds functions to the `king_phisher.serializers` module to allow better serialization of arbitrary Python values into XML elements to be placed in documents. This is most notably used by the logic for exporting campaigns in the XML format.

Note that these are serializer functions and not a class like the existing JSON and MsgPack ones are. The reason is that those serializers do not take additional information such as the parent element and tag name. That makes these new functions incompatible with that interface.

Testing steps:

 - [x] Read the documentation and ensure it makes sense
 - [x] Make the type cover is sufficient for most needs
 - [x] Make sure all unit tests pass