### PR TITLE
Add Additional Default Client Configuration Keys

### DIFF
--- a/data/client/king_phisher/client_config.json
+++ b/data/client/king_phisher/client_config.json
@@ -16,13 +16,17 @@
   "server": "localhost:22",
   "server_remote_port": 80,
   "server_use_ssl": false,
+  "server_username": "",
   "sftp_client": "filezilla --logontype=interactive sftp://{username}@{server}{web_root}",
   "ssh_preferred_key": null,
   "smtp_max_send_rate": 45.0,
   "smtp_server": "localhost:25",
   "smtp_ssh_enable": false,
   "smtp_ssl_enable": false,
+  "smtp_username": "",
   "spf_check_level": 1,
+  "ssh_server": "localhost:22",
+  "ssh_username": "",
   "text_font": "monospace 11",
   "text_source_theme": "cobalt"
 }

--- a/king_phisher/client/application.py
+++ b/king_phisher/client/application.py
@@ -470,9 +470,8 @@ class KingPhisherClientApplication(_Gtk_Application):
 	def merge_config(self, config_file, strict=True):
 		"""
 		Merge the configuration information from the specified configuration
-		file. Only keys which exist in the currently loaded configuration are
-		copied over while non-existent keys are skipped. The contents of the new
-		configuration overwrites the existing.
+		file. All keys and values will overwrite or be added to the existing
+		configuration settings.
 
 		:param bool strict: Do not try remove trailing commas from the JSON data.
 		:param str config_file: The path to the configuration file to merge.
@@ -484,9 +483,6 @@ class KingPhisherClientApplication(_Gtk_Application):
 			return
 		self.logger.debug('merging configuration information from source file: ' + config_file)
 		for key, value in config.items():
-			if not key in self.config:
-				self.logger.warning("skipped merging non-existent configuration key {0}".format(key))
-				continue
 			self.config[key] = value
 		return
 

--- a/king_phisher/client/application.py
+++ b/king_phisher/client/application.py
@@ -470,8 +470,9 @@ class KingPhisherClientApplication(_Gtk_Application):
 	def merge_config(self, config_file, strict=True):
 		"""
 		Merge the configuration information from the specified configuration
-		file. All keys and values will overwrite or be added to the existing
-		configuration settings.
+		file. Only keys which exist in the currently loaded configuration are
+		copied over while non-existent keys are skipped. The contents of the new
+		configuration overwrites the existing.
 
 		:param bool strict: Do not try remove trailing commas from the JSON data.
 		:param str config_file: The path to the configuration file to merge.
@@ -483,6 +484,9 @@ class KingPhisherClientApplication(_Gtk_Application):
 			return
 		self.logger.debug('merging configuration information from source file: ' + config_file)
 		for key, value in config.items():
+			if not key in self.config:
+				self.logger.warning("skipped merging non-existent configuration key {0}".format(key))
+				continue
 			self.config[key] = value
 		return
 


### PR DESCRIPTION
# Description
~~This PR changes the `merge_config` function to allow new keys to be create and values set during the merging process.~~
Updated base user configuration file to support default keys to facilitate importing common key values from another configuration file, while still maintaining a white list.

Custom profiles/configs not loading required default keys during import causing stack traces to occur later in the program. Primary example at this time is SMTP setting, using ssh connections.

![thumbnail_kingphisher-error](https://cloud.githubusercontent.com/assets/9035933/24357831/f20286f8-12cc-11e7-974a-0e15d3bc4104.jpg)

```
ERROR    error uid: bb8c1231-8c6d-4cc3-8740-7da020450bf9 an unhandled exception was thrown
Traceback (most recent call last):
  File "/opt/king-phisher/king_phisher/client/tabs/mail.py", line 292, in signal_button_clicked_sender_start
    if not self._sender_precheck_spf():
  File "/opt/king-phisher/king_phisher/client/tabs/mail.py", line 228, in _sender_precheck_spf
    spf_test_ip = mailer.guess_smtp_server_address(self.config['smtp_server'], (self.config['ssh_server'] if self.config['smtp_ssh_enable'] else None))
KeyError: 'ssh_server'
```


# Testing
- [ ] Remove current `.config/king-phisher/config.json` file.
- [ ] On the login window right click and import configuration file, that has keys not set on default load, example key `ssh_server`
- [ ] Login and then then close King Phisher
- [ ] Cat out `~/.config/king-phisher/config.json' to verify import was successful 