### PR TITLE
Updated windows build tools to python3.4

### DIFF
--- a/docs/source/change_log.rst
+++ b/docs/source/change_log.rst
@@ -16,6 +16,8 @@ Version 1.8.0
 * Support the client on OS X by using Docker
 * Support for issuing certificates  with acme while the server is running
 * Add a wrapping tool for certbot to make the process easier
+* Updated `tools/cx_freeze.py` to build KingPhisher client in Python 3.4
+* Updated documentation for windows build.
 
 Version 1.7.1
 ^^^^^^^^^^^^^

--- a/docs/source/development/windows_build.rst
+++ b/docs/source/development/windows_build.rst
@@ -40,7 +40,50 @@ as text entries. Below is the name fields and example values.
 +--------------------------------+---------------------------------+
 | Name                           | Example Value                   |
 +================================+=================================+
-| Python Version                 | 2.7.11                          |
+| Python Version                 | 3.4                             |
 +--------------------------------+---------------------------------+
 | PyGI-AIO Version               | 3.14.0 rev22                    |
 +--------------------------------+---------------------------------+
+
+Python 3.4 Build
+----------------
+
+As of King Phisher Version 1.8, the windows client is built with Python 3.4.
+To install basemaps for Python 3.4 you will have to compile geos one windows.
+On top of installing the requirements for pip that are not included in the
+requirements.txt file are pypiwin32api, and numpy.
+
+For information on how to build goes on windows with CMake visit:
+https://trac.osgeo.org/geos/wiki/BuildingOnWindowsWithCMake
+
+A difference in the instructions in the above link, we use the geos package
+that comes with basemaps, just copy out the folder and compile with the same steps.
+
+Once geos is complied copy the two generated DLLs `geos.dll` and `geos_c.dll`
+to `[python34]\libs\site-packages\`
+
+*Note if you are using C++ 2010 Express or older, you might have to add in
+functions for floor and ceiling into the geos code, as the library it utilizes
+for these functions is not available.
+
+CX Freeze version 5.0.1
+-----------------------
+
+After building and installing the MSI, if the short cut link fails because it cannot `from . import xxx`,
+it is because the working directory for the shortcut is not set.
+
+To change this so builds have the working directory set automatically, you need to change the last
+`None` to `"TARGETDIR"` on line 62 of `[python34]\Lib\site-packages\cx_Freeze\windist.py`.
+
+The ouput example of lines 52-62 of cx_freeze's `windist.py` file, with change applied.
+```
+for index, executable in enumerate(self.distribution.executables):
+    if executable.shortcutName is not None \
+            and executable.shortcutDir is not None:
+        baseName = os.path.basename(executable.targetName)
+        msilib.add_data(self.db, "Shortcut",
+                [("S_APP_%s" % index, executable.shortcutDir,
+                        executable.shortcutName, "TARGETDIR",
+                        "[TARGETDIR]%s" % baseName, None, None, None,
+                        None, None, None, "TARGETDIR")])
+```

--- a/tools/cx_freeze.py
+++ b/tools/cx_freeze.py
@@ -50,24 +50,27 @@ include_dll_path = os.path.join(site.getsitepackages()[1], 'gnome')
 
 # DLLs from site-packages\gnome\ last updated for pygi-aio 3.14.0 rev22
 missing_dlls = [
+	'lib\enchant\libenchant_aspell.dll',
+	'lib\enchant\libenchant_hspell.dll',
+	'lib\enchant\libenchant_ispell.dll',
+	'lib\enchant\libenchant_myspell.dll',
+	'lib\enchant\libenchant_voikko.dll',
+	'lib\gio\modules\libgiognomeproxy.dll',
+	'lib\gio\modules\libgiolibproxy.dll',
 	'libaspell-15.dll',
 	'libatk-1.0-0.dll',
 	'libcairo-gobject-2.dll',
 	'libdbus-1-3.dll',
 	'libdbus-glib-1-2.dll',
 	'libenchant-1.dll',
-	'lib\enchant\libenchant_myspell.dll',
-	'lib\enchant\libenchant_voikko.dll',
-	'lib\enchant\libenchant_ispell.dll',
 	'libffi-6.dll',
 	'libfontconfig-1.dll',
 	'libfreetype-6.dll',
 	'libgailutil-3-0.dll',
-	'libgdk-3-0.dll',
 	'libgdk_pixbuf-2.0-0.dll',
+	'libgdk-3-0.dll',
 	'libgeoclue-0.dll',
 	'libgio-2.0-0.dll',
-	'lib\gio\modules\libgiolibproxy.dll',
 	'libgirepository-1.0-1.dll',
 	'libglib-2.0-0.dll',
 	'libgmodule-2.0-0.dll',
@@ -81,10 +84,9 @@ missing_dlls = [
 	'libgstvideo-1.0-0.dll',
 	'libgtk-3-0.dll',
 	'libgtksourceview-3.0-1.dll',
-	'libgnutls-26.dll',
-	'libgconf-2-4.dll',
-	'libharfbuzz-gobject-0.dll',
+	'libharfbuzz-0.dll',
 	'libintl-8.dll',
+	'libjasper-1.dll',
 	'libjavascriptcoregtk-3.0-0.dll',
 	'libjpeg-8.dll',
 	'liborc-0.4-0.dll',
@@ -115,6 +117,14 @@ gtk_libs = ['etc', 'lib', 'share']
 for lib in gtk_libs:
 	include_files.append((os.path.join(include_dll_path, lib), lib))
 
+# include windows complied version of geos for basemaps
+include_files.append((os.path.join(site.getsitepackages()[1], 'geos.dll'), 'geos.dll'))
+include_files.append((os.path.join(site.getsitepackages()[1], 'geos_c.dll'), 'geos_c.dll'))
+include_files.append((os.path.join(site.getsitepackages()[1], '_geoslib.pyd'), '_geoslib.pyd'))
+include_files.append((os.path.join(site.getsitepackages()[0], 'libs\geos_c.lib'), 'libs\geos_c.lib'))
+include_files.append((os.path.join(site.getsitepackages()[0], 'libs\geos.lib'), 'libs\geos.lib'))
+
+
 include_files.append((matplotlib.get_data_path(), 'mpl-data'))
 include_files.append((basemap.basemap_datadir, 'mpl-basemap-data'))
 include_files.append(('data/client/king_phisher', 'king_phisher'))
@@ -136,9 +146,9 @@ executables = [
 ]
 
 build_exe_options = dict(
-	compressed=False,
 	include_files=include_files,
 	packages=[
+		'_geoslib',
 		'boltons',
 		'cairo',
 		'cffi',
@@ -147,17 +157,23 @@ build_exe_options = dict(
 		'email',
 		'gi',
 		'icalendar',
+		'idna',
 		'jinja2',
+		'king_phisher.client',
 		'matplotlib',
 		'mpl_toolkits',
 		'msgpack',
-		'OpenSSL',
+		'numpy',
+		'requests',
 		'paramiko',
 		'pkg_resources',
 		'pluginbase',
 		'smoke_zephyr',
+		'win32api',
+		'websocket',
+		'xlsxwriter',
 	],
-	excludes=['collections.abc']
+	excludes=['jinja2.asyncfilters', 'jinja2.asyncsupport'], # not supported with python 3.4
 )
 
 setup(


### PR DESCRIPTION
This PR updates the `tools/cx_freeze.py` for dll and package requirements for use with python 3.4. This PR also updates documentation for additional information concerning builds in windows with python 3.4.

- [ ] Documentation makes since
- [ ] Documentation builds
- [ ] No DLLs or packages are missing in `tools/cx_freeze.py` for the King Phisher client
