### PR TITLE
Add free automated flake8 testing on all pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: python
 python:
     # - 2.7.13  # no longer supported
     - 3.6.2
+branches:
+    only:
+        - dev
+        - master
 install:
     - pip install flake8  # pytest  # add other testing frameworks later
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+python:
+    # - 2.7.13  # no longer supported
+    - 3.6.2
+install:
+    - pip install flake8  # pytest  # add other testing frameworks later
+before_script:
+    # stop the build if there are Python syntax errors or undefined names
+    - time flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - time flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+    - true  # add other tests here
+notifications:
+    on_success: change
+    on_failure: always


### PR DESCRIPTION
The owner of the this repo would need to go to https://travis-ci.org/profile and flip on the repository switch to enable free automated testing on each pull request.  This could be adapted to run __pylint__ instead of flake8