### PR TITLE
DNS timeout issues

### DIFF
--- a/data/client/king_phisher/client_config.json
+++ b/data/client/king_phisher/client_config.json
@@ -27,6 +27,7 @@
   "smtp_ssl_enable": false,
   "smtp_username": "",
   "spf_check_level": 1,
+  "spf_check_timeout": 10,
   "ssh_server": "localhost:22",
   "ssh_username": "",
   "text_font": "monospace 11",

--- a/king_phisher/client/tabs/mail.py
+++ b/king_phisher/client/tabs/mail.py
@@ -243,7 +243,13 @@ class MailSenderSendTab(gui_utilities.GladeGObject):
 		spf_test_sender, spf_test_domain = self.config['mailer.source_email_smtp'].split('@')
 		self.text_insert("Checking the SPF policy of target domain '{0}'... ".format(spf_test_domain))
 		try:
-			spf_result = spf.check_host(spf_test_ip, spf_test_domain, sender=spf_test_sender)
+			spf_result = spf.check_host(spf_test_ip, spf_test_domain, timeout=self.config['spf_check_timeout'], sender=spf_test_sender)
+		except spf.SPFTimeOutError:
+			dialog_title = 'Sender Policy Framework Failure'
+			dialog_message = 'Timeout on DNS query, unable to confirm SPF Records.\n\nContinue sending messages anyways?'
+			if not gui_utilities.show_dialog_yes_no(dialog_title, self.parent, dialog_message):
+				self.text_insert('\nSending aborted due to the DNS query timeout during policy check.\n')
+				return False
 		except spf.SPFError as error:
 			self.text_insert("done, encountered exception: {0}.\n".format(error.__class__.__name__))
 			return True


### PR DESCRIPTION
toThis PR addresses issue #233 where the client become unresponive during SPF checks. With this PR King Phisher will now time out by default at 10 seconds if it has not recieved a response to the DNS query. This option can be changed in the client configuration file with the option `spf_check_timeout`. Furthermore this PR update the SPF query to try all DNS servers. If they fail, it will move to the next, and then remove all DNS servers from its list to one that successfully made response to speed up the process of SPF checking.

To validate:
- [ ] Run King Phisher send an email should work normally
- [ ] Change Primary DNS server to a fake server or ip address that is not a DNS server
- [ ] Run King Phisher will 'hang' for a few seconds then a dialog box will ask say that a timeout occurred and ask the user if you want to continue.
- [ ] Changing the `spf_check_timeout` changes the timeout period when querying DNS server.
