### PR TITLE
Fixed import error in requirment check

### DIFF
--- a/king_phisher/plugins.py
+++ b/king_phisher/plugins.py
@@ -170,7 +170,10 @@ class Requirements(_Mapping):
 		missing_packages = []
 		for package in packages:
 			if package.startswith('gi.'):
-				if not importlib.util.find_spec(package):
+				try:
+					if not importlib.util.find_spec(package):
+						missing_packages.append(package)
+				except ImportError:
 					missing_packages.append(package)
 				continue
 			package_check = smoke_zephyr.requirements.check_requirements([package])


### PR DESCRIPTION
This pull request fixes an import issue that is generated when using `importlib.util.find_spec`

To reproduce the issue,
- [x] uninstall gtkspell check. `sudo apt remove gir1.2-gtkspell3-3.0` 
- [x] run King Phisher and open plugin manager, should get a stack trace, that is below

To test:
- [x] make sure gtkspell is uninstalled
- [x] pull down pull request 
- [x] run King Phisher and open plugin manager, no stack trace, and requirements show `No` 

stack trace that caused the issue
```
Exception in thread Thread-33:
Traceback (most recent call last):
  File "<frozen importlib._bootstrap>", line 890, in _find_spec
AttributeError: 'DynamicImporter' object has no attribute 'find_spec'
 
During handling of the above exception, another exception occurred:
 
Traceback (most recent call last):
  File "/usr/lib/python3.5/threading.py", line 914, in _bootstrap_inner
    self.run()
  File "/opt/king-phisher/king_phisher/utilities.py", line 502, in run
    super(Thread, self).run()
  File "/usr/lib/python3.5/threading.py", line 862, in run
    self._target(*self._args, **self._kwargs)
  File "/opt/king-phisher/king_phisher/client/windows/plugin_manager.py", line 168, in _load_catalogs
    self._load_plugins()
  File "/opt/king-phisher/king_phisher/client/windows/plugin_manager.py", line 245, in _load_plugins
    self._add_plugins_to_tree(catalog_id, repo, store, repo_row, plugin_collections)
  File "/opt/king-phisher/king_phisher/client/windows/plugin_manager.py", line 278, in _add_plugins_to_tree
    compatibility='Yes' if self.catalog_plugins.is_compatible(catalog_id, repo.id, plugin) else 'No',
  File "/opt/king-phisher/king_phisher/client/plugins.py", line 693, in is_compatible
    return plugins.Requirements(plugin['requirements']).is_compatible
  File "/opt/king-phisher/king_phisher/plugins.py", line 151, in is_compatible
    for req_type, req_details, req_met in self.compatibility_iter():
  File "/opt/king-phisher/king_phisher/plugins.py", line 162, in compatibility_iter
    missing_packages = self._check_for_missing_packages(self._storage['packages'])
  File "/opt/king-phisher/king_phisher/plugins.py", line 173, in _check_for_missing_packages
    if not importlib.util.find_spec(package):
  File "/usr/lib/python3.5/importlib/util.py", line 89, in find_spec
    return _find_spec(fullname, parent.__path__)
  File "<frozen importlib._bootstrap>", line 892, in _find_spec
  File "<frozen importlib._bootstrap>", line 873, in _find_spec_legacy
  File "/usr/lib/python3/dist-packages/gi/importer.py", line 127, in find_module
    'introspection typelib not found' % namespace)
ImportError: cannot import name GtkSpell, introspection typelib not found
```