### PR TITLE
Better plugin cache

### DIFF
--- a/king_phisher/catalog.py
+++ b/king_phisher/catalog.py
@@ -511,6 +511,15 @@ class CatalogManager(object):
 			return
 		return catalog
 
+	def add_catalog_dict(self, dict_):
+		try:
+			catalog = Catalog(dict_)
+			self.catalogs[catalog.id] = catalog
+		except Exception as error:
+			self.logger.warning("failed to load catalog from dict due to {}".format(error))
+			return
+		return catalog
+
 def sign_item_files(local_path, signing_key, repo_path=None):
 	"""
 	This utility function is used to create a :py:class:`.CollectionItemFile`

--- a/king_phisher/catalog.py
+++ b/king_phisher/catalog.py
@@ -495,36 +495,15 @@ class CatalogManager(object):
 		"""
 		return tuple(self.catalogs[catalog_id].repositories.values())
 
-	def add_catalog_url(self, url):
+	def add_catalog(self, catalog):
 		"""
-		Adds the specified catalog to the manager by its URL.
+		Adds the specified catalog to the manager.
 
-		:param str url: The URL of the catalog to load.
+		:param :py:class:.'Catalog' catalog:
 		:return: The catalog.
 		:rtype: :py:class:`.Catalog`
 		"""
-		try:
-			catalog = Catalog.from_url(url)
-			self.catalogs[catalog.id] = catalog
-		except Exception as error:
-			self.logger.warning("failed to load catalog from url {0} due to {1}".format(url, error))
-			return
-		return catalog
-
-	def add_catalog_dict(self, dict_):
-		"""
-		Adds the specified catalog to the manager by its dict.
-
-		:param dict dict_: The dict of the catalog to load.
-		:return: The catalog.
-		:rtype: :py:class:`.Catalog`
-		"""
-		try:
-			catalog = Catalog(dict_)
-			self.catalogs[catalog.id] = catalog
-		except Exception as error:
-			self.logger.warning("failed to load catalog from dict due to {}".format(error))
-			return
+		self.catalogs[catalog.id] = catalog
 		return catalog
 
 def sign_item_files(local_path, signing_key, repo_path=None):

--- a/king_phisher/catalog.py
+++ b/king_phisher/catalog.py
@@ -512,6 +512,13 @@ class CatalogManager(object):
 		return catalog
 
 	def add_catalog_dict(self, dict_):
+		"""
+		Adds the specified catalog to the manager by its dict.
+
+		:param dict dict_: The dict of the catalog to load.
+		:return: The catalog.
+		:rtype: :py:class:`.Catalog`
+		"""
 		try:
 			catalog = Catalog(dict_)
 			self.catalogs[catalog.id] = catalog

--- a/king_phisher/client/plugins.py
+++ b/king_phisher/client/plugins.py
@@ -493,7 +493,7 @@ class ClientPluginMailerAttachment(ClientPlugin):
 	def __init__(self, *args, **kwargs):
 		super(ClientPluginMailerAttachment, self).__init__(*args, **kwargs)
 		mailer_tab = self.application.main_tabs['mailer']
-		self.signal_connect('send-target', self._signal_send_target, gobject=mailer_tab)
+		self.signal_connect('target-create', self._signal_send_target, gobject=mailer_tab)
 
 	def _signal_send_target(self, _, target):
 		config = self.application.config

--- a/king_phisher/client/windows/plugin_manager.py
+++ b/king_phisher/client/windows/plugin_manager.py
@@ -193,8 +193,9 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 				self.idle_show_dialog_error('Catalog Loading Error', 'Catalog Dictionary is malformed')
 		elif isinstance(catalog, str):
 			try:
-				url_catalog = Catalog.from_url(catalog)
-				self.catalog_plugins.add_catalog(url_catalog, cache=True)
+				catalog_url = catalog
+				catalog = Catalog.from_url(catalog)
+				self.catalog_plugins.add_catalog(catalog, catalog_url=catalog_url, cache=True)
 			except requests.exceptions.ConnectionError:
 				self.logger.warning("connection error trying to download catalog url: {}".format(catalog))
 				self.idle_show_dialog_error('Catalog Loading Error', "Failed to download catalog, Please check your internet connection")
@@ -216,11 +217,12 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 		:return: catalog ID of the associated catalog url or None
 		:rtype: str
 		"""
-		cache = self.catalog_plugins.get_cache().get_all_base_urls()
-		for catalog_id in cache:
-			for base_url in cache[catalog_id]:
-				if base_url in catalog_url:
-					return catalog_id
+		cache = self.catalog_plugins.get_cache().get_catalog_urls()
+		for catalog_id, catalog_urls in cache.items():
+			if not catalog_urls:
+				continue
+			if catalog_url in catalog_urls:
+				return catalog_id
 		return None
 
 	def __update_status_bar(self, string_to_set):


### PR DESCRIPTION
# This PR updates the catalog cache to 2.0. 

The catalog cache now holds all off the catalog information to be loaded from disc, thus saving aggravating seconds when developing plugins for King Phisher. 

# Check list functions
[ ] If the cache is less then 4 hours old Catalog will be loaded from the local cache. 
[ ] Right clicking in the treeview and selecting reload all, will fetch catalogs by url.
[ ] Plugin Manager Window loads faster after it is running on catalog cache 2.0