### PR TITLE
Catalog reload

### DIFF
--- a/king_phisher/client/windows/plugin_manager.py
+++ b/king_phisher/client/windows/plugin_manager.py
@@ -178,17 +178,22 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 					continue
 			self.logger.debug("downloading catalog: {}".format(catalog_url))
 			self._update_status_bar("Loading, downloading catalog: {}".format(catalog_url))
-			try:
-				catalog = Catalog.from_url(catalog_url)
-			except requests.exceptions.ConnectionError:
-				self.logger.warning("connection error trying to download catalog url: {}".format(catalog))
-				self.idle_show_dialog_error('Catalog Loading Error', "Failed to download catalog, check your internet connection.")
-			except Exception:
-				self.logger.warning("failed to add catalog by url", exc_info=True)
-				self.idle_show_dialog_error('Catalog Loading Error', "Failed to add catalog")
-			else:
-				self.catalog_plugins.add_catalog(catalog, catalog_url=catalog_url, cache=True)
+			catalog = self._load_catalog_from_url(catalog_url)
+			if not catalog:
+				continue
+			self.catalog_plugins.add_catalog(catalog, catalog_url=catalog_url, cache=True)
 		self._load_plugins()
+
+	def _load_catalog_from_url(self, catalog_url):
+		try:
+			catalog = Catalog.from_url(catalog_url)
+		except requests.exceptions.ConnectionError:
+			self.logger.warning("connection error trying to download catalog url: {}".format(catalog_url))
+			self.idle_show_dialog_error('Catalog Loading Error', "Failed to download catalog, check your internet connection.")
+		except Exception:
+			self.logger.warning("failed to add catalog by url", exc_info=True)
+			self.idle_show_dialog_error('Catalog Loading Error', "Failed to add catalog")
+		return catalog
 
 	def idle_show_dialog_error(self, title, message):
 		gui_utilities.glib_idle_add_once(gui_utilities.show_dialog_error, title, self.window, message)
@@ -262,15 +267,7 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 
 		self.logger.debug('loading catalog into plugin treeview')
 		for catalog_id in self.catalog_plugins.catalog_ids():
-			model = (catalog_id, None, True, catalog_id, None, None, False, False, False, _ROW_TYPE_CATALOG)
-			catalog_row = gui_utilities.glib_idle_add_wait(self._store_append, store, None, model)
-			for repo in self.catalog_plugins.get_repositories(catalog_id):
-				model = (repo.id, None, True, repo.title, None, None, False, False, False, _ROW_TYPE_REPOSITORY)
-				repo_row = gui_utilities.glib_idle_add_wait(self._store_append, store, catalog_row, model)
-				plugin_collections = self.catalog_plugins.get_collection(catalog_id, repo.id)
-				if not plugin_collections:
-					continue
-				self._add_plugins_to_tree(catalog_id, repo, store, repo_row, plugin_collections)
+			self._add_catalog_to_tree(catalog_id, store)
 
 		catalog_cache = self.catalog_plugins.get_cache()
 		for catalog_id in catalog_cache:
@@ -286,6 +283,17 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 
 		gui_utilities.glib_idle_add_once(self._treeview_unselect)
 		self._update_status_bar('Loading completed', idle=True)
+
+	def _add_catalog_to_tree(self, catalog_id, store):
+		model = (catalog_id, None, True, catalog_id, None, None, False, False, False, _ROW_TYPE_CATALOG)
+		catalog_row = gui_utilities.glib_idle_add_wait(self._store_append, store, None, model)
+		for repo in self.catalog_plugins.get_repositories(catalog_id):
+			model = (repo.id, None, True, repo.title, None, None, False, False, False, _ROW_TYPE_REPOSITORY)
+			repo_row = gui_utilities.glib_idle_add_wait(self._store_append, store, catalog_row, model)
+			plugin_collections = self.catalog_plugins.get_collection(catalog_id, repo.id)
+			if not plugin_collections:
+				continue
+			self._add_plugins_to_tree(catalog_id, repo, store, repo_row, plugin_collections)
 
 	def _add_plugins_to_tree(self, catalog_id, repo, store, parent, plugin_list):
 		models = []
@@ -402,6 +410,12 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 		return not self.gobjects['expander_info'].get_property('expanded')
 
 	def signal_popup_menu_activate_reload(self, _):
+		if not self.load_thread.is_alive():
+			self.load_thread = utilities.Thread(target=self._reload)
+			self.load_thread.start()
+
+	def _reload(self):
+		self._update_status_bar("Reloading... ")
 		treeview = self.gobjects['treeview_plugins']
 		pm = self.application.plugin_manager
 		selected_plugin = None
@@ -413,14 +427,23 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 		for tree_iter in gui_utilities.gtk_treeview_selection_iterate(treeview):
 			model_row = self._model[tree_iter]
 			# only reloading installed plugins is currently supported
-			if model_row.parent is None:
-				continue
 			named_row = self._named_model(*model_row)
 			if named_row.type != _ROW_TYPE_PLUGIN:
-				continue
+				if model_row.parent is None:
+					self._model.remove(tree_iter)
+					catalog_url = self.catalog_plugins.get_cache().get_catalog_by_id(named_row.id)['url']
+				else:
+					parent_row = self._named_model(*model_row.parent)
+					self._model.remove(model_row.parent.iter)
+					catalog_url = self.catalog_plugins.get_cache().get_catalog_by_id(parent_row.id)['url']
+				catalog = self._load_catalog_from_url(catalog_url)
+				if not catalog:
+					continue
+				self.catalog_plugins.add_catalog(catalog, catalog_url=catalog_url, cache=True)
+				self._load_plugins()
+
 			if not named_row.installed:
 				continue
-
 			enabled = named_row.id in pm.enabled_plugins
 			pm.unload(named_row.id)
 			try:
@@ -467,11 +490,13 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 		repo_model, catalog_model = self._get_plugin_model_parents(self._model[path])
 		named_row = self._named_model(*self._model[path])
 		if named_row.installed:
+			self._update_status_bar("Uninstalling: {}".format(named_row.id))
 			if named_row.enabled:
 				if not gui_utilities.show_dialog_yes_no('Plugin is enabled', self.window, 'This will disable the plugin, do you want to continue?'):
 					return
 				self._disable_plugin(path)
 			self._uninstall_plugin(path)
+			self._update_status_bar("Completed uninstalling: {}".format(named_row.id))
 			return
 
 		if named_row.id in self.config['plugins.installed']:
@@ -484,6 +509,7 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 					self.logger.warning("failed to uninstall plugin {0}".format(named_row.id))
 					return
 
+		self._update_status_bar("Installing plugin: {}".format(named_row.title))
 		try:
 			self.catalog_plugins.install_plugin(catalog_model.id, repo_model.id, named_row.id, self.plugin_path)
 		except requests.exceptions.ConnectionError:
@@ -493,12 +519,14 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 		except Exception:
 			self.logger.warning("failed to install plugin {}".format(named_row.id), exc_info=True)
 			gui_utilities.show_dialog_error('Failed To Install', self.window, "Failed to install {} plugin.".format(named_row.id))
+			self._update_status_bar("Failed To Install".format(named_row.id))
 			return
 
 		self.config['plugins.installed'][named_row.id] = {'catalog_id': catalog_model.id, 'repo_id': repo_model.id, 'plugin_id': named_row.id}
 		self._set_model_item(path, 'installed', True)
 		self._set_model_item(path, 'version', self.catalog_plugins.get_collection(catalog_model.id, repo_model.id)[named_row.id]['version'])
 		self.logger.info("installed plugin {} from catalog:{}, repository:{}".format(named_row.id, catalog_model.id, repo_model.id))
+		self._update_status_bar("Completed installing plugin: {}".format(named_row.title))
 		self.application.plugin_manager.load_all(on_error=self._on_plugin_load_error)
 
 	def _disable_plugin(self, path, is_path=True):


### PR DESCRIPTION
This PR updates the plugin to allow for the user to force reload the selected catalog.
If a repository is selected it will reload the top level catalog.
Updated install/uninstall methods to display information on status bar, so it is more verbose to end user.

To test
- [x] Open Plugin Manager
- [x] select a catalog row, right click and select `reload`
  - [x] Selected catalog is removed and reloaded.
- [x] select a repository row, right click and select `reload`
  - [x] Repository's top level catalog is removed and reloaded.
- [x] select an installed plugin, right click and select `reload`
  - [x] selected plugin reloads
