### PR TITLE
Feat/gui email

### DIFF
--- a/data/client/king_phisher/king-phisher-client.ui
+++ b/data/client/king_phisher/king-phisher-client.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.4 
+<!-- Generated with glade 3.20.0 
 
 Copyright (c) 2013-2017, SecureState LLC
 All rights reserved.
@@ -115,9 +115,6 @@ Spencer McIntyre</property>
           <placeholder/>
         </child>
       </object>
-    </child>
-    <child>
-      <placeholder/>
     </child>
   </object>
   <object class="GtkWindow" id="CampaignCompWindow">
@@ -411,9 +408,6 @@ Spencer McIntyre</property>
       <action-widget response="-6">CampaignSelectionDialog.button_cancel</action-widget>
       <action-widget response="-10">CampaignSelectionDialog.button_select</action-widget>
     </action-widgets>
-    <child>
-      <placeholder/>
-    </child>
   </object>
   <object class="GtkBox" id="CampaignViewCredentialsTab">
     <property name="width_request">400</property>
@@ -1816,9 +1810,6 @@ Spencer McIntyre</property>
       <action-widget response="-6">CompanyEditorDialog.button_cancel</action-widget>
       <action-widget response="-10">CompanyEditorDialog.button_apply</action-widget>
     </action-widgets>
-    <child>
-      <placeholder/>
-    </child>
   </object>
   <object class="GtkGrid" id="CompanyEditorGrid">
     <property name="visible">True</property>
@@ -2192,9 +2183,6 @@ Spencer McIntyre</property>
     <action-widgets>
       <action-widget response="-5">button1</action-widget>
     </action-widgets>
-    <child>
-      <placeholder/>
-    </child>
   </object>
   <object class="GtkApplicationWindow" id="ImportCampaignWindow">
     <property name="width_request">600</property>
@@ -2569,9 +2557,6 @@ Spencer McIntyre</property>
       <action-widget response="-6">LoginDialogBase.button_cancel</action-widget>
       <action-widget response="-10">LoginDialogBase.button_connect</action-widget>
     </action-widgets>
-    <child>
-      <placeholder/>
-    </child>
     <style>
       <class name="background-add"/>
     </style>
@@ -3472,9 +3457,6 @@ Spencer McIntyre</property>
       <action-widget response="-6">LoginDialog.button_cancel</action-widget>
       <action-widget response="-10">LoginDialog.button_connect</action-widget>
     </action-widgets>
-    <child>
-      <placeholder/>
-    </child>
     <style>
       <class name="background-add"/>
     </style>
@@ -3707,7 +3689,7 @@ Spencer McIntyre</property>
                               </object>
                               <packing>
                                 <property name="left_attach">0</property>
-                                <property name="top_attach">0</property>
+                                <property name="top_attach">1</property>
                               </packing>
                             </child>
                             <child>
@@ -3719,7 +3701,7 @@ Spencer McIntyre</property>
                               </object>
                               <packing>
                                 <property name="left_attach">0</property>
-                                <property name="top_attach">1</property>
+                                <property name="top_attach">2</property>
                               </packing>
                             </child>
                             <child>
@@ -3733,7 +3715,7 @@ Spencer McIntyre</property>
                               </object>
                               <packing>
                                 <property name="left_attach">1</property>
-                                <property name="top_attach">0</property>
+                                <property name="top_attach">1</property>
                               </packing>
                             </child>
                             <child>
@@ -3752,7 +3734,32 @@ Spencer McIntyre</property>
                               </object>
                               <packing>
                                 <property name="left_attach">1</property>
-                                <property name="top_attach">1</property>
+                                <property name="top_attach">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="label28">
+                                <property name="width_request">120</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Email Address</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkEntry" id="ConfigurationDialog.entry_email_address">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="tooltip_text" translatable="yes">The email address to send alerts to.</property>
+                                <property name="hexpand">True</property>
+                                <property name="placeholder_text" translatable="yes">user.email@domain.com</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="top_attach">0</property>
                               </packing>
                             </child>
                           </object>
@@ -4467,9 +4474,6 @@ Spencer McIntyre</property>
       <action-widget response="-6">ConfigurationDialog.button_cancel</action-widget>
       <action-widget response="-10">ConfigurationDialog.button_apply</action-widget>
     </action-widgets>
-    <child>
-      <placeholder/>
-    </child>
   </object>
   <object class="GtkImage" id="StockAddImage">
     <property name="visible">True</property>
@@ -4705,9 +4709,6 @@ Spencer McIntyre</property>
       <action-widget response="-6">ClonePageDialog.button_cancel</action-widget>
       <action-widget response="-10">ClonePageDialog.button_clone</action-widget>
     </action-widgets>
-    <child>
-      <placeholder/>
-    </child>
   </object>
   <object class="GtkImage" id="StockHelpImage">
     <property name="visible">True</property>
@@ -5556,9 +5557,6 @@ host key will store it for identification verification of future connections.</p
       <action-widget response="-2">HostKeyAcceptDialog.button_reject</action-widget>
       <action-widget response="-3">HostKeyAcceptDialog.button_accept</action-widget>
     </action-widgets>
-    <child>
-      <placeholder/>
-    </child>
   </object>
   <object class="GtkDialog" id="HostKeyWarnDialog">
     <property name="width_request">450</property>
@@ -5773,9 +5771,6 @@ your communications. Please contact the system administrator.</property>
       <action-widget response="-3">HostKeyWarnDialog.button_accept</action-widget>
       <action-widget response="-2">HostKeyWarnDialog.button_reject</action-widget>
     </action-widgets>
-    <child>
-      <placeholder/>
-    </child>
   </object>
   <object class="GtkDialog" id="TagEditorDialog">
     <property name="width_request">450</property>
@@ -5922,9 +5917,6 @@ your communications. Please contact the system administrator.</property>
     <action-widgets>
       <action-widget response="-7">TagEditorDialog.button_close</action-widget>
     </action-widgets>
-    <child>
-      <placeholder/>
-    </child>
   </object>
   <object class="GtkDialog" id="TextEntryDialog">
     <property name="can_focus">False</property>
@@ -6026,9 +6018,6 @@ your communications. Please contact the system administrator.</property>
       <action-widget response="-6">TextEntryDialog.button_cancel</action-widget>
       <action-widget response="-10">TextEntryDialog.button_apply</action-widget>
     </action-widgets>
-    <child>
-      <placeholder/>
-    </child>
   </object>
   <object class="GtkAdjustment" id="TimeDuration">
     <property name="lower">1</property>


### PR DESCRIPTION
This feature intends to add alert notifications via SMTP using the smtp2go api. 
This is basically a copy/paste of the sms_clockwork alert plugin with substituted functions. Changes in the UI include adding an gtk_entry widget for users to submit their email to receive notifications.

- [ ] Add alerts_smtp.py plugin from king-phisher-plugins to /data/king_phisher/server/plugins/
- [ ] Add the following lines to KingPhisher's server_config.yml
```
plugins:
   alerts_smtp:
      api_key: 'api-abcdef0123456789101112'
      server_email: 'notifications@king-phisher.com'
```
api_key is the smtp2go.com API key required to send notification emails.
The server_email is the email address notifications will be sent from.
- [ ] Copy king_phisher_client.ui to /data/client/ and test that client loads new UI correctly. 
- [ ] Create new campaign configured to send alerts via smtp (Client Campaign Advanced Setup tab)
- [ ] Verify adding user email results in notifications sent and received when new-unique clicks are detected.
