### PR TITLE
Updated db initailization failed message to be more descriptive

### DIFF
--- a/king_phisher/server/database/manager.py
+++ b/king_phisher/server/database/manager.py
@@ -340,8 +340,8 @@ def init_database(connection_url, extra_init=False):
 		if error.args:
 			match = re.match(r'\(psycopg2\.OperationalError\) FATAL:\s+password authentication failed for user \"(?P<username>\w+)\"$', error.args[0])
 			if match:
-				raise errors.KingPhisherDatabaseAuthenticationError('initialization failed', username=match.group('username')) from None
-		raise errors.KingPhisherDatabaseError('initialization failed') from error
+				raise errors.KingPhisherDatabaseAuthenticationError('database initialization failed', username=match.group('username')) from None
+		raise errors.KingPhisherDatabaseError('database initialization failed') from error
 
 	if 'campaigns' not in inspector.get_table_names():
 		logger.debug('campaigns table not found, creating all new tables')


### PR DESCRIPTION
I'm not really sure you're guys convention for error handling so I figured I'd just throw this out there, spent about 10 minutes figuring out that my DB was not configured correctly. "initialization failed" is a very generic error message to return to the top-level, but "database initialization failed" would at least give me a better idea of where to start looking. Plus, all other instance of `KingPhisherDatabaseError` appeared to give some indication it was DB related in the message.