### PR TITLE
Training Tables

### DIFF
--- a/data/server/king_phisher/alembic/versions/ba93bbe6d6_schema_v9.py
+++ b/data/server/king_phisher/alembic/versions/ba93bbe6d6_schema_v9.py
@@ -94,7 +94,7 @@ def upgrade():
 	)
 
 	op.create_table(
-		'actual_answers',
+		'actual_answers_link_test_answers',
 		sqlalchemy.Column('id', sqlalchemy.Integer, primary_key=True),
 		sqlalchemy.Column('test_question_id', sqlalchemy.Integer, sqlalchemy.ForeignKey('test_questions.id'), nullable=False),
 		sqlalchemy.Column('test_answers.id', sqlalchemy.Integer, sqlalchemy.ForeignKey('test_answers.id'), nullable=False)
@@ -117,7 +117,7 @@ def downgrade():
 		'tests',
 		'test_modules',
 		'test_answers',
-		'actual_answers'
+		'actual_answers_link_test_answers'
 	]
 
 	for table in tables:

--- a/data/server/king_phisher/alembic/versions/ba93bbe6d6_schema_v9.py
+++ b/data/server/king_phisher/alembic/versions/ba93bbe6d6_schema_v9.py
@@ -67,6 +67,7 @@ def upgrade():
 		sqlalchemy.Column('description', sqlalchemy.String),
 		sqlalchemy.Column('hint', sqlalchemy.String),
 		sqlalchemy.Column('url_reference', sqlalchemy.String),
+		sqlalchemy.Column('url_hint', sqlalchemy.String),
 		sqlalchemy.Column('test_answer_id', sqlalchemy.Integer, sqlalchemy.ForeignKey('test_answers.id'))
 	)
 
@@ -92,6 +93,13 @@ def upgrade():
 		sqlalchemy.Column('test_module_id', sqlalchemy.Integer, sqlalchemy.ForeignKey('test_modules.id'), nullable=False)
 	)
 
+	op.create_table(
+		'actual_answers',
+		sqlalchemy.Column('id', sqlalchemy.Integer, primary_key=True),
+		sqlalchemy.Column('test_question_id', sqlalchemy.Integer, sqlalchemy.ForeignKey('test_questions.id'), nullable=False),
+		sqlalchemy.Column('test_answers.id', sqlalchemy.Integer, sqlalchemy.ForeignKey('test_answers.id'), nullable=False)
+	)
+
 	db_manager.Session.remove()
 	db_manager.Session.configure(bind=op.get_bind())
 	session = db_manager.Session()
@@ -108,7 +116,8 @@ def downgrade():
 		'test_submissions',
 		'tests',
 		'test_modules',
-		'test_answers'
+		'test_answers',
+		'actual_answers'
 	]
 
 	for table in tables:

--- a/data/server/king_phisher/alembic/versions/ba93bbe6d6_schema_v9.py
+++ b/data/server/king_phisher/alembic/versions/ba93bbe6d6_schema_v9.py
@@ -1,0 +1,121 @@
+"""schema v9
+
+Revision ID: ba93bb36d6
+Revises: b8443afcb9e
+Create Date: 2018-05-31 15:34:31.667556
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'ba93bb36d6'
+down_revision = 'b8443afcb9e'
+
+import os
+import sys
+sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), *['..'] * 5)))
+
+from alembic import op
+from king_phisher.server.database import manager as db_manager
+from king_phisher.server.database import schema_migration as db_schema_migration
+import sqlalchemy
+
+
+def upgrade():
+
+	op.create_table(
+		'test_answers',
+		sqlalchemy.Column('id', sqlalchemy.Integer, primary_key=True),
+		sqlalchemy.Column('answer', sqlalchemy.String, nullable=False),
+		sqlalchemy.Column('case_sensitive', sqlalchemy.Boolean),
+	)
+
+	op.create_table(
+		'test_modules',
+		sqlalchemy.Column('id', sqlalchemy.Integer, primary_key=True),
+		sqlalchemy.Column('name', sqlalchemy.String, nullable=False),
+		sqlalchemy.Column('description', sqlalchemy.String),
+		sqlalchemy.Column('created', sqlalchemy.DateTime)
+	)
+
+	op.create_table(
+		'tests',
+		sqlalchemy.Column('id', sqlalchemy.Integer, primary_key=True),
+		sqlalchemy.Column('name', sqlalchemy.Integer, nullable=False),
+		sqlalchemy.Column('description', sqlalchemy.String),
+		sqlalchemy.Column('created', sqlalchemy.DateTime),
+		sqlalchemy.Column('minimum_score', sqlalchemy.Integer, nullable=False),
+		sqlalchemy.Column('max_attempts', sqlalchemy.Integer),
+		sqlalchemy.Column('user_id', sqlalchemy.Integer, sqlalchemy.ForeignKey('users.id'), nullable=False)
+	)
+
+	op.add_column('campaigns', sqlalchemy.Column('test_id', sqlalchemy.Integer, sqlalchemy.ForeignKey('tests.id'),))
+
+	op.create_table(
+		'test_submissions',
+		sqlalchemy.Column('id', sqlalchemy.Integer, primary_key=True),
+		sqlalchemy.Column('campaign_id', sqlalchemy.Integer, sqlalchemy.ForeignKey('campaigns.id'), nullable=False),
+		sqlalchemy.Column('created', sqlalchemy.DateTime),
+		sqlalchemy.Column('test_id', sqlalchemy.Integer, sqlalchemy.ForeignKey('tests.id'), nullable=False),
+		sqlalchemy.Column('visit_id', sqlalchemy.String, sqlalchemy.ForeignKey('visits.id'), nullable=False),
+	)
+
+	op.create_table(
+		'test_questions',
+		sqlalchemy.Column('id', sqlalchemy.Integer, primary_key=True),
+		sqlalchemy.Column('question', sqlalchemy.String, nullable=False),
+		sqlalchemy.Column('question_type', sqlalchemy.String, nullable=False),
+		sqlalchemy.Column('description', sqlalchemy.String),
+		sqlalchemy.Column('hint', sqlalchemy.String),
+		sqlalchemy.Column('url_reference', sqlalchemy.String),
+		sqlalchemy.Column('test_answer_id', sqlalchemy.Integer, sqlalchemy.ForeignKey('test_answers.id'))
+	)
+
+	op.create_table(
+		'test_question_link_test_answer',
+		sqlalchemy.Column('id', sqlalchemy.Integer, primary_key=True),
+		sqlalchemy.Column('test_answer_id', sqlalchemy.Integer, sqlalchemy.ForeignKey('test_answers.id'), nullable=False),
+		sqlalchemy.Column('test_question_id', sqlalchemy.Integer, sqlalchemy.ForeignKey('test_questions.id'), nullable=False)
+	)
+
+	op.create_table(
+		'test_submission_link_test_answer',
+		sqlalchemy.Column('id', sqlalchemy.Integer, primary_key=True),
+		sqlalchemy.Column('test_submission_id', sqlalchemy.Integer, sqlalchemy.ForeignKey('test_submissions.id'), nullable=False),
+		sqlalchemy.Column('test_question_id', sqlalchemy.Integer, sqlalchemy.ForeignKey('test_questions.id'), nullable=False),
+		sqlalchemy.Column('test_answer_id', sqlalchemy.Integer, sqlalchemy.ForeignKey('test_answers.id'), nullable=False)
+	)
+
+	op.create_table(
+		'test_link_test_module',
+		sqlalchemy.Column('id', sqlalchemy.Integer, primary_key=True),
+		sqlalchemy.Column('test_id', sqlalchemy.Integer, sqlalchemy.ForeignKey('tests.id'), nullable=False),
+		sqlalchemy.Column('test_module_id', sqlalchemy.Integer, sqlalchemy.ForeignKey('test_modules.id'), nullable=False)
+	)
+
+	db_manager.Session.remove()
+	db_manager.Session.configure(bind=op.get_bind())
+	session = db_manager.Session()
+	db_manager.set_metadata('schema_version', 9, session=session)
+	session.commit()
+
+def downgrade():
+	op.drop_column('campaigns', 'test_id')
+	tables = [
+		'test_link_test_module',
+		'test_submission_link_test_answer',
+		'test_question_link_test_answer',
+		'test_questions',
+		'test_submissions',
+		'tests',
+		'test_modules',
+		'test_answers'
+	]
+
+	for table in tables:
+		op.drop_table(table)
+
+	db_manager.Session.remove()
+	db_manager.Session.configure(bind=op.get_bind())
+	session = db_manager.Session()
+	db_manager.set_metadata('schema_version', 8, session=session)
+	session.commit()

--- a/data/server/king_phisher/alembic/versions/ba93bbe6d6_schema_v9.py
+++ b/data/server/king_phisher/alembic/versions/ba93bbe6d6_schema_v9.py
@@ -16,7 +16,6 @@ sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), *['..
 
 from alembic import op
 from king_phisher.server.database import manager as db_manager
-from king_phisher.server.database import schema_migration as db_schema_migration
 import sqlalchemy
 
 

--- a/king_phisher/server/database/models.py
+++ b/king_phisher/server/database/models.py
@@ -423,6 +423,7 @@ class Module(TagMixIn, Base):
 @register_table
 class PossibleAnswerLink(Base):
 	__repr_attributes__ = ('group_id', 'answer_id')
+	__tablename__ = 'possible_answer_link'
 	id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
 	question_answer_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('question_answers.id'), nullable=False)
 	group_id = sqlalchemy.Column(sqlalchemy.Integer)
@@ -481,6 +482,7 @@ class TestSubmission(Base):
 @register_table
 class TestModuleLink(Base):
 	__repr_attributes__ = ('test_id', 'module_id')
+	__tablename__ = 'test_module_link'
 	id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
 	test_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('tests.id'), nullable=False)
 	module_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('modules.id'), nullable=False)

--- a/king_phisher/server/database/models.py
+++ b/king_phisher/server/database/models.py
@@ -408,10 +408,10 @@ class TestQuestion(Base):
 	description = sqlalchemy.Column(sqlalchemy.String)
 	hint = sqlalchemy.Column(sqlalchemy.String)
 	url_reference = sqlalchemy.Column(sqlalchemy.String)
-	test_question_link_test_answer_group = sqlalchemy.Column(sqlalchemy.Integer, nullable=False)
 	test_answer_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('test_answers.id'))
 	# relationships
 	submission_answer_link = sqlalchemy.orm.relationship('TestSubmissionLinkTestAnswer', backref='test_questions', cascade='all, delete-orphan')
+	test_question_link_test_answer = sqlalchemy.orm.relationship('TestQuestionLinkTestAnswer', backref='test_questions', cascade='all, delete-orphan')
 
 @register_table
 class TestModule(TagMixIn, Base):
@@ -427,7 +427,7 @@ class TestQuestionLinkTestAnswer(Base):
 	__tablename__ = 'test_question_link_test_answer'
 	id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
 	test_answer_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('test_answers.id'), nullable=False)
-	group_id = sqlalchemy.Column(sqlalchemy.Integer)
+	test_question_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('test_questions.id'), nullable=False)
 
 @register_table
 class TestAnswer(Base):

--- a/king_phisher/server/database/models.py
+++ b/king_phisher/server/database/models.py
@@ -188,7 +188,7 @@ class BaseRowCls(object):
 	@classmethod
 	def session_has_read_access(cls, session, instance=None):
 		return not cls.is_private
-
+possible_answer_group
 	@classmethod
 	def session_has_read_prop_access(cls, session, prop, instance=None):
 		return cls.session_has_read_access(session, instance=instance)
@@ -399,67 +399,68 @@ class Message(Base):
 	visits = sqlalchemy.orm.relationship('Visit', backref='message', cascade='all, delete-orphan')
 
 @register_table
-class ModuleQuestion(Base):
+class TestQuestion(Base):
 	__repr_attributes__ = ('question',)
-	__tablename__ = 'module_questions'
+	__tablename__ = 'test_questions'
 	id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
 	question = sqlalchemy.Column(sqlalchemy.String, nullable=False)
 	question_type = sqlalchemy.Column(sqlalchemy.String, nullable=False)
+	description = sqlalchemy.Column(sqlalchemy.String)
 	hint = sqlalchemy.Column(sqlalchemy.String)
 	url_reference = sqlalchemy.Column(sqlalchemy.String)
-	possible_answer_group_id = sqlalchemy.Column(sqlalchemy.Integer, nullable=False)
-	question_answer_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('question_answers.id'))
+	test_question_link_test_answer_group = sqlalchemy.Column(sqlalchemy.Integer, nullable=False)
+	test_answer_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('test_answers.id'))
 	# relationships
-	submission_answer_link = sqlalchemy.orm.relationship('SubmissionAnswerLink', backref='module_questions', cascade='all, delete-orphan')
+	submission_answer_link = sqlalchemy.orm.relationship('TestSubmissionLinkTestAnswer', backref='test_questions', cascade='all, delete-orphan')
 
 @register_table
-class Module(TagMixIn, Base):
-	__tablename__ = 'modules'
-	created = sqlalchemy.Column(sqlalchemy.DateTime, nullable=False)
+class TestModule(TagMixIn, Base):
+	__tablename__ = 'test_modules'
+	created = sqlalchemy.Column(sqlalchemy.DateTime, default=current_timestamp)
 	# relationships
-	module_question = sqlalchemy.orm.relationship('ModuleQuestion', backref='modules', cascade='all, delete-orphan')
-	test_module = sqlalchemy.orm.relationship('TestModule', backref='modules', cascade='all, delete-orphan')
+	module_question = sqlalchemy.orm.relationship('TestQuestion', backref='test_modules', cascade='all, delete-orphan')
+	test_link_test_module = sqlalchemy.orm.relationship('TestLinkTestModule', backref='test_modules', cascade='all, delete-orphan')
 
 @register_table
-class PossibleAnswerLink(Base):
+class TestQuestionLinkTestAnswer(Base):
 	__repr_attributes__ = ('group_id', 'answer_id')
-	__tablename__ = 'possible_answer_link'
+	__tablename__ = 'test_question_link_test_answer'
 	id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-	question_answer_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('question_answers.id'), nullable=False)
+	test_answer_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('test_answers.id'), nullable=False)
 	group_id = sqlalchemy.Column(sqlalchemy.Integer)
 
 @register_table
-class QuestionAnswer(Base):
+class TestAnswer(Base):
 	__repr_attributes__ = ('answer',)
-	__tablename__ = 'question_answers'
+	__tablename__ = 'test_answers'
 	id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-	answer = sqlalchemy.Column(sqlalchemy.String, nullable=False, unique=True)
-	case_sensitive = sqlalchemy.Column(sqlalchemy.Boolean, nullable=False, default=False)
+	answer = sqlalchemy.Column(sqlalchemy.String, nullable=False)
+	case_sensitive = sqlalchemy.Column(sqlalchemy.Boolean, default=False)
 	# relationships
-	module_question = sqlalchemy.orm.relationship('ModuleQuestion', backref='question_answers', cascade='all, delete-orphan')
-	submission_answers = sqlalchemy.orm.relationship('SubmissionAnswersLink', backref='question_answers', cascade='all, delete-orphan')
-	possible_answer_link = sqlalchemy.orm.relationship('PossibleAnswerLink', backref='QuestionAnswer', cascade='all, delete-orphan')
+	module_question = sqlalchemy.orm.relationship('TestQuestion', backref='test_answers', cascade='all, delete-orphan')
+	submission_answers = sqlalchemy.orm.relationship('SubmissionAnswersLink', backref='test_answers', cascade='all, delete-orphan')
+	test_question_link_test_answer = sqlalchemy.orm.relationship('TestQuestionLinkTestAnswer', backref='test_answers', cascade='all, delete-orphan')
 
 @register_table
-class SubmissionAnswerLink(Base):
+class TestSubmissionLinkTestAnswer(Base):
 	__repr_attributes__ = ('test_sub_id', 'module_question_id', 'answer_id')
-	__tablename__ = 'submission_answers_link'
+	__tablename__ = 'test_submission_link_test_answer'
 	id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-	test_sub_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('test_submissions.id'), nullable=False)
-	module_question_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('module_questions.id'), nullable=False)
-	question_answer_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('question_answers.id'), nullable=False)
+	test_submission_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('test_submissions.id'), nullable=False)
+	test_question_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('test_questions.id'), nullable=False)
+	test_answer_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('test_answers.id'), nullable=False)
 
 @register_table
 class Test(TagMixIn, Base):
 	__repr_attributes__ = ('name', 'minimum_score')
 	__tablename__ = 'tests'
-	created = sqlalchemy.Column(sqlalchemy.DateTime, nullable=False)
+	created = sqlalchemy.Column(sqlalchemy.DateTime, default=current_timestamp)
 	minimum_score = sqlalchemy.Column(sqlalchemy.Integer, nullable=False)
-	retakes = sqlalchemy.Column(sqlalchemy.Integer, default=0, nullable=False)
+	max_attempts = sqlalchemy.Column(sqlalchemy.Integer, default=1)
 	user_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('users.id'), nullable=False)
 	# relationships
-	test_submission = sqlalchemy.orm.relationship('TestSubmission', backref='tests', cascade='all, delete-orphan')
-	test_modules = sqlalchemy.orm.relationship('TestModule', backref='tests', cascade='all, delete-orphan')
+	test_submissions = sqlalchemy.orm.relationship('TestSubmission', backref='tests', cascade='all, delete-orphan')
+	test_link_test_module = sqlalchemy.orm.relationship('TestLinkTestModule', backref='tests', cascade='all, delete-orphan')
 
 @register_table
 class TestSubmission(Base):
@@ -467,25 +468,25 @@ class TestSubmission(Base):
 	__tablename__ = 'test_submissions'
 	id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
 	campaign_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('campaign.id'), nullable=False)
-	created = sqlalchemy.Column(sqlalchemy.DateTime, nullable=False)
+	created = sqlalchemy.Column(sqlalchemy.DateTime, default=current_timestamp)
 	test_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('tests.id'), nullable=False)
 	visit_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('visits.id'), nullable=False)
 	# relationships
-	submission_answers_link = sqlalchemy.orm.relationship('SubmissionAnswersLink', backref='test_submissions', cascade='all, delete-orphan')
+	test_submission_link_test_answer = sqlalchemy.orm.relationship('SubmissionAnswersLink', backref='test_submissions', cascade='all, delete-orphan')
 
 	"""
-	Need to-do classmethods
+	Need to-do instance methods
 		grade (calculates test score)
 		pass (returns true or false if grade was passing)
 	"""
 
 @register_table
-class TestModuleLink(Base):
+class TestLinkTestModule(Base):
 	__repr_attributes__ = ('test_id', 'module_id')
-	__tablename__ = 'test_module_link'
+	__tablename__ = 'test_link_test_module'
 	id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
 	test_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('tests.id'), nullable=False)
-	module_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('modules.id'), nullable=False)
+	test_module_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('test_modules.id'), nullable=False)
 
 @register_table
 class User(ExpireMixIn, Base):
@@ -502,6 +503,7 @@ class User(ExpireMixIn, Base):
 	# relationships
 	alert_subscriptions = sqlalchemy.orm.relationship('AlertSubscription', backref='user', cascade='all, delete-orphan')
 	campaigns = sqlalchemy.orm.relationship('Campaign', backref='user', cascade='all, delete-orphan')
+	tests = sqlalchemy.orm.relationship('Tests', backref='user', cascade='all, delete-orphan')
 
 	@classmethod
 	def session_has_create_access(cls, session, instance=None):
@@ -541,4 +543,4 @@ class Visit(Base):
 	last_seen = sqlalchemy.Column(sqlalchemy.DateTime, default=current_timestamp)
 	# relationships
 	credentials = sqlalchemy.orm.relationship('Credential', backref='visit', cascade='all, delete-orphan')
-	test_submission = sqlalchemy.orm.relationship('TestSubmission', backref='visit', cascade='all, delete-orphan')
+	test_submissions = sqlalchemy.orm.relationship('TestSubmission', backref='visit', cascade='all, delete-orphan')

--- a/king_phisher/server/database/models.py
+++ b/king_phisher/server/database/models.py
@@ -188,7 +188,7 @@ class BaseRowCls(object):
 	@classmethod
 	def session_has_read_access(cls, session, instance=None):
 		return not cls.is_private
-possible_answer_group
+
 	@classmethod
 	def session_has_read_prop_access(cls, session, prop, instance=None):
 		return cls.session_has_read_access(session, instance=instance)
@@ -443,7 +443,7 @@ class TestAnswer(Base):
 
 @register_table
 class TestSubmissionLinkTestAnswer(Base):
-	__repr_attributes__ = ('test_sub_id', 'module_question_id', 'answer_id')
+	__repr_attributes__ = ('test_submission_id', 'module_question_id', 'answer_id')
 	__tablename__ = 'test_submission_link_test_answer'
 	id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
 	test_submission_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('test_submissions.id'), nullable=False)

--- a/king_phisher/server/database/models.py
+++ b/king_phisher/server/database/models.py
@@ -47,7 +47,7 @@ import sqlalchemy.sql.expression
 
 DATABASE_TABLE_REGEX = '[a-z_]+'
 """A regular expression which will match all valid database table names."""
-SCHEMA_VERSION = 8
+SCHEMA_VERSION = 9
 """The schema version of the database, used for compatibility checks."""
 
 MetaTable = collections.namedtuple('MetaTable', ('column_names', 'model', 'name'))
@@ -418,7 +418,6 @@ class TestModule(TagMixIn, Base):
 	__tablename__ = 'test_modules'
 	created = sqlalchemy.Column(sqlalchemy.DateTime, default=current_timestamp)
 	# relationships
-	module_question = sqlalchemy.orm.relationship('TestQuestion', backref='test_modules', cascade='all, delete-orphan')
 	test_link_test_module = sqlalchemy.orm.relationship('TestLinkTestModule', backref='test_modules', cascade='all, delete-orphan')
 
 @register_table
@@ -438,7 +437,7 @@ class TestAnswer(Base):
 	case_sensitive = sqlalchemy.Column(sqlalchemy.Boolean, default=False)
 	# relationships
 	module_question = sqlalchemy.orm.relationship('TestQuestion', backref='test_answers', cascade='all, delete-orphan')
-	submission_answers = sqlalchemy.orm.relationship('SubmissionAnswersLink', backref='test_answers', cascade='all, delete-orphan')
+	test_submission_link_test_answer = sqlalchemy.orm.relationship('TestSubmissionLinkTestAnswer', backref='test_answers', cascade='all, delete-orphan')
 	test_question_link_test_answer = sqlalchemy.orm.relationship('TestQuestionLinkTestAnswer', backref='test_answers', cascade='all, delete-orphan')
 
 @register_table
@@ -472,7 +471,7 @@ class TestSubmission(Base):
 	test_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('tests.id'), nullable=False)
 	visit_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('visits.id'), nullable=False)
 	# relationships
-	test_submission_link_test_answer = sqlalchemy.orm.relationship('SubmissionAnswersLink', backref='test_submissions', cascade='all, delete-orphan')
+	test_submission_link_test_answer = sqlalchemy.orm.relationship('TestSubmissionLinkTestAnswer', backref='test_submissions', cascade='all, delete-orphan')
 
 	"""
 	Need to-do instance methods
@@ -503,7 +502,7 @@ class User(ExpireMixIn, Base):
 	# relationships
 	alert_subscriptions = sqlalchemy.orm.relationship('AlertSubscription', backref='user', cascade='all, delete-orphan')
 	campaigns = sqlalchemy.orm.relationship('Campaign', backref='user', cascade='all, delete-orphan')
-	tests = sqlalchemy.orm.relationship('Tests', backref='user', cascade='all, delete-orphan')
+	tests = sqlalchemy.orm.relationship('Test', backref='user', cascade='all, delete-orphan')
 
 	@classmethod
 	def session_has_create_access(cls, session, instance=None):

--- a/king_phisher/server/database/models.py
+++ b/king_phisher/server/database/models.py
@@ -412,7 +412,7 @@ class TestQuestion(Base):
 	# relationships
 	submission_answer_link = sqlalchemy.orm.relationship('TestSubmissionLinkTestAnswer', backref='test_questions', cascade='all, delete-orphan')
 	test_question_link_test_answer = sqlalchemy.orm.relationship('TestQuestionLinkTestAnswer', backref='test_questions', cascade='all, delete-orphan')
-	actual_answers = sqlalchemy.orm.relationship('ActualAnswers', backref='test_questions', cascade='all, delete-orphan')
+	actual_answer_link_test_answer = sqlalchemy.orm.relationship('ActualAnswersLinkTestAnswer', backref='test_questions', cascade='all, delete-orphan')
 
 @register_table
 class TestModule(TagMixIn, Base):
@@ -430,7 +430,7 @@ class TestQuestionLinkTestAnswer(Base):
 	test_question_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('test_questions.id'), nullable=False)
 
 @register_table
-class ActualAnswers(Base):
+class ActualAnswersLinkTestAnswer(Base):
 	__repr_attributes__ = ('test_question_id', 'test_answer_id')
 	__tablename__ = 'actual_answers'
 	id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
@@ -448,6 +448,7 @@ class TestAnswer(Base):
 	module_question = sqlalchemy.orm.relationship('TestQuestion', backref='test_answers', cascade='all, delete-orphan')
 	test_submission_link_test_answer = sqlalchemy.orm.relationship('TestSubmissionLinkTestAnswer', backref='test_answers', cascade='all, delete-orphan')
 	test_question_link_test_answer = sqlalchemy.orm.relationship('TestQuestionLinkTestAnswer', backref='test_answers', cascade='all, delete-orphan')
+	actual_answer_link_test_answer = sqlalchemy.orm.relationship('ActualAnswerLinkTestAnswer', backref='test_answers', cascade='all, delete-orphan')
 
 @register_table
 class TestSubmissionLinkTestAnswer(Base):

--- a/king_phisher/server/database/models.py
+++ b/king_phisher/server/database/models.py
@@ -408,10 +408,11 @@ class TestQuestion(Base):
 	description = sqlalchemy.Column(sqlalchemy.String)
 	hint = sqlalchemy.Column(sqlalchemy.String)
 	url_reference = sqlalchemy.Column(sqlalchemy.String)
-	test_answer_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('test_answers.id'))
+	url_hint = sqlalchemy.Column(sqlalchemy.String)
 	# relationships
 	submission_answer_link = sqlalchemy.orm.relationship('TestSubmissionLinkTestAnswer', backref='test_questions', cascade='all, delete-orphan')
 	test_question_link_test_answer = sqlalchemy.orm.relationship('TestQuestionLinkTestAnswer', backref='test_questions', cascade='all, delete-orphan')
+	actual_answers = sqlalchemy.orm.relationship('ActualAnswers', backref='test_questions', cascade='all, delete-orphan')
 
 @register_table
 class TestModule(TagMixIn, Base):
@@ -422,8 +423,16 @@ class TestModule(TagMixIn, Base):
 
 @register_table
 class TestQuestionLinkTestAnswer(Base):
-	__repr_attributes__ = ('group_id', 'answer_id')
+	__repr_attributes__ = ('test_answer_id', 'test_question_id')
 	__tablename__ = 'test_question_link_test_answer'
+	id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
+	test_answer_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('test_answers.id'), nullable=False)
+	test_question_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('test_questions.id'), nullable=False)
+
+@register_table
+class ActualAnswers(Base):
+	__repr_attributes__ = ('test_question_id', 'test_answer_id')
+	__tablename__ = 'actual_answers'
 	id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
 	test_answer_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('test_answers.id'), nullable=False)
 	test_question_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('test_questions.id'), nullable=False)


### PR DESCRIPTION
This PR adds the additional tables required for the new training features into King Phisher's database models.

These tables will hold data for the following items:
- Tests
 - Holds the base meta data associated to a test
- Tests Modules
  - This table is primarily a link table to allow multiple references modules the makes up the test)
- Modules
  - References all the questions associated with the module
- Question Answers for both possible answers, submitted answers and real answers
- Possible Answers
 - this table is a link table for the Questions to be linked to a group of possible answers for the question.
- Test Submissions
  - Holds the base data of the submitted tests
- Submission Answers
 - holds the answers to the test that was submitted.

This PR has the alembic file to upgrade the database to version 9 to hold all the important information for all the training information.

- [ ] test downgrade
  - [ ] change directory to `data/server/king-phisher`
  - [ ] run command `alembic -x config={path to king phisher server_config.yml} downgrade b8443afcb9e` 
