### PR TITLE
Load plugins for missing catalogs/repos

### DIFF
--- a/king_phisher/client/windows/plugin_manager.py
+++ b/king_phisher/client/windows/plugin_manager.py
@@ -688,6 +688,10 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 	#
 	def _load_catalogs_tsafe(self, refresh=False):
 		self._installed_plugins_treeview_tracker = copy.deepcopy(self.config['plugins.installed'])
+		for plugin in self._installed_plugins_treeview_tracker:
+			# Remove plugins already found to be locally installed.
+			if not self._installed_plugins_treeview_tracker[plugin]:
+				self._installed_plugins_treeview_tracker.pop(plugin)
 		if refresh:
 			gui_utilities.glib_idle_add_once(self._model.clear)
 		expiration = datetime.timedelta(seconds=smoke_zephyr.utilities.parse_timespan(self.config.get('cache.age', '4h')))


### PR DESCRIPTION
This PR fixes a bug where an installed is not loaded into the plugin managers tree view. This occurs when the plugin's collection/catalog/repo is not loaded into the plugin manager, or when the plugin itself is not found in its catalog it was installed from. This would occur if a branch, or the plugin itself is deleted from its download source. 

The PR does this by making a deepcopy of the user's config file of installed plugins and as the plugin manager adds those plugins to the treeview during the loading process it removes them from this temporary dict. If there was any plugins left over they did not make it into the tree view, thus it was not found in any of the catalogs loaded. It then sets the users configuration file to treat the plugin as locally installed, and refreshes the local repository node to the user can still enable and disable the plugin accordingly.

Testing:
- [x] Plugin manger loads
- [x] Install a plugin from one of the repos (IE Dev)
- [x] Close King Phisher gracefully
- [x] Open the users configuration file
  - [x] Under `plugins.installed` find the plugin you installed
  - [x] change either `catalog_id`, `repo_id`, or `plugin_id`
  - [x] save user configuration file
- [x] start King Phisher
- [x] Login and open the plugin manager, you should find the plugin under the local repository section
- [x] repeat steps for the other two variables not tested in the user configuration file.