### PR TITLE
Windows build fixs

### DIFF
--- a/data/client/king_phisher/style/theme.v1.css
+++ b/data/client/king_phisher/style/theme.v1.css
@@ -442,10 +442,13 @@ GtkWindow:hover {
   padding: 5px 5px 6px; }
   .multilineentry:insensitive {
     background-color: alpha(darkgray, 0.8); }
-  .multilineentry > GtkTextView {
+  .multilineentry GtkTextView {
     background-color: transparent;
     background-image: none;
     color: @theme_color_0; }
-    .multilineentry > GtkTextView:selected {
+    .multilineentry GtkTextView:selected {
       background-color: @theme_color_1;
       color: white; }
+    .multilineentry GtkTextView:insensitive {
+      background-color: alpha(darkgray, 0.8);
+      background-image: none; }

--- a/king_phisher/client/application.py
+++ b/king_phisher/client/application.py
@@ -133,7 +133,7 @@ class KingPhisherClientApplication(_Gtk_Application):
 	def __init__(self, config_file=None, use_plugins=True, use_style=True):
 		super(KingPhisherClientApplication, self).__init__()
 		if use_style:
-			if Gtk.check_version(3, 18, 0):
+			if Gtk.check_version(3, 18, 0) or its.on_windows:
 				self._theme_file = 'theme.v1.css'
 			else:
 				self._theme_file = 'theme.v2.css'

--- a/king_phisher/version.py
+++ b/king_phisher/version.py
@@ -45,6 +45,8 @@ import collections
 import os
 import subprocess
 
+from king_phisher import its
+
 def get_revision(encoding='utf-8'):
 	"""
 	Retrieve the current git revision identifier. If the git binary can not be
@@ -60,7 +62,7 @@ def get_revision(encoding='utf-8'):
 			('git', 'rev-parse', 'HEAD'),
 			stdout=subprocess.PIPE,
 			stderr=subprocess.PIPE,
-			close_fds=True,
+			close_fds=False if its.on_windows else True,
 			cwd=os.path.dirname(os.path.abspath(__file__))
 		)
 	except OSError:

--- a/tools/development/build_msi.bat
+++ b/tools/development/build_msi.bat
@@ -1,11 +1,30 @@
 @echo off
 @setlocal
 
+:Variables
 set start=%time%
+
+:: make entry point for King Phisher client build
+copy king_phisher\client\__main__.py .\KingPhisher
+if %ERRORLEVEL% NEQ 0 (
+	echo Failed to copy client entry point
+	echo Error level: %ERRORLEVEL%
+	exit /b %ERRORLEVEL%
+)
 
 :: perform the build
 python tools\development\cx_freeze.py build
+if %ERRORLEVEL% NEQ 0 (
+	echo Failed to build King Phisher exe
+	echo Error level: %ERRORLEVEL%
+	exit /b %ERRORLEVEL%
+)
 python tools\development\cx_freeze.py bdist_msi
+if %ERRORLEVEL% NEQ 0 (
+	echo Failed to build King Phisher msi package
+	echo Error level: %ERRORLEVEL%
+	exit /b %ERRORLEVEL%
+)
 
 :: build complete, calculate the time elapsed
 set end=%time%

--- a/tools/development/cx_freeze.py
+++ b/tools/development/cx_freeze.py
@@ -31,10 +31,11 @@
 #
 
 import os
+import re
 import site
 import sys
 
-sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
 
 from king_phisher import version
 
@@ -127,14 +128,6 @@ for path in os.listdir(site.getsitepackages()[1]):
 	if os.path.isdir(os.path.join(site.getsitepackages()[1], path)):
 		include_files.append((os.path.join(site.getsitepackages()[1], path), path))
 
-# include windows complied version of geos for basemaps
-include_files.append((os.path.join(site.getsitepackages()[1], 'geos.dll'), 'geos.dll'))
-include_files.append((os.path.join(site.getsitepackages()[1], 'geos_c.dll'), 'geos_c.dll'))
-include_files.append((os.path.join(site.getsitepackages()[1], '_geoslib.pyd'), '_geoslib.pyd'))
-include_files.append((os.path.join(site.getsitepackages()[0], 'libs', 'geos_c.lib'), os.path.join('libs', 'geos_c.lib')))
-include_files.append((os.path.join(site.getsitepackages()[0], 'libs', 'geos.lib'), os.path.join('libs', 'geos.lib')))
-
-
 include_files.append((matplotlib.get_data_path(), 'mpl-data'))
 include_files.append((basemap.basemap_datadir, 'mpl-basemap-data'))
 include_files.append(('data/client/king_phisher', 'king_phisher'))
@@ -203,7 +196,7 @@ build_exe_options = dict(
 setup(
 	name='KingPhisher',
 	author='SecureState',
-	version=version.distutils_version,
+	version=re.sub("[^0-9.]", "", version.distutils_version),
 	description='King Phisher Client',
 	options=dict(build_exe=build_exe_options),
 	executables=executables

--- a/tools/development/cx_freeze.py
+++ b/tools/development/cx_freeze.py
@@ -31,7 +31,6 @@
 #
 
 import os
-import re
 import site
 import sys
 
@@ -193,10 +192,12 @@ build_exe_options = dict(
 	excludes=['jinja2.asyncfilters', 'jinja2.asyncsupport'], # not supported with python 3.4
 )
 
+version_build = '.'.join((str(version.version_info[0]), str(version.version_info[1]), str(version.version_info[2])))
 setup(
 	name='KingPhisher',
 	author='SecureState',
-	version=re.sub("[^0-9.]", "", version.distutils_version),
+	version=version_build,
+	comments="build version: {}".format(version.distutils_version),
 	description='King Phisher Client',
 	options=dict(build_exe=build_exe_options),
 	executables=executables


### PR DESCRIPTION
This PR fixes a couple of issues and makes improvements for the windows build.

* an incompatibility use issue with close_fds in the version file. It will now be false if found to be on windows.
* will now default to Gtk style CSSv1 file if on windows, no more manually changing files
* for `build_msi.bat` added in error level checking for build commands, allowing it to cleanly exit the script and report the error code.
* `cx_freeze.py` will now use `re.sub` to get version from the version file, as `cx_freeze` does not allow letters to be in versions.
* `cx_freeze.py` is now set to be used from the development tools folder, and removed goes from manually being bundled.