### PR TITLE
Fedora29 and Ubuntu18 headless install fixes

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ alembic = "==0.9.7"
 blinker = "==1.4"
 boltons = "==18.0.0"
 cryptography = "==2.1.4"
+Cython = "==0.29"
 dnspython = "==1.15.0"
 ecdsa = "==0.13"
 "geoip2" = "==2.8.0"
@@ -47,6 +48,7 @@ SQLAlchemy = "==1.2.6"
 XlsxWriter = "==0.9.6"
 numpy = "==1.14.5"
 "basemap" = {file = "https://github.com/matplotlib/basemap/archive/v1.2.0rel.tar.gz"}
+pyproj = {git = "https://github.com/jswhit/pyproj.git"}
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "028ebb662efb648c3fb9ebe7d33e2048000cae68f95b5d846433284a6427df00"
+            "sha256": "26e0fb663ae3d443e3178b4cac2f62973bb65631d505a8adef0b69eab2af7b7a"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -179,6 +179,40 @@
                 "sha256:cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8"
             ],
             "version": "==0.10.0"
+        },
+        "cython": {
+            "hashes": [
+                "sha256:019008a69e6b7c102f2ed3d733a288d1784363802b437dd2b91e6256b12746da",
+                "sha256:1441fe19c56c90b8c2159d7b861c31a134d543ef7886fd82a5d267f9f11f35ac",
+                "sha256:1d1a5e9d6ed415e75a676b72200ad67082242ec4d2d76eb7446da255ae72d3f7",
+                "sha256:339f5b985de3662b1d6c69991ab46fdbdc736feb4ac903ef6b8c00e14d87f4d8",
+                "sha256:35bdf3f48535891fee2eaade70e91d5b2cc1ee9fc2a551847c7ec18bce55a92c",
+                "sha256:3d0afba0aec878639608f013045697fb0969ff60b3aea2daec771ea8d01ad112",
+                "sha256:42c53786806e24569571a7a24ebe78ec6b364fe53e79a3f27eddd573cacd398f",
+                "sha256:48b919da89614d201e72fbd8247b5ae8881e296cf968feb5595a015a14c67f1f",
+                "sha256:49906e008eeb91912654a36c200566392bd448b87a529086694053a280f8af2d",
+                "sha256:49fc01a7c9c4e3c1784e9a15d162c2cac3990fcc28728227a6f8f0837aabda7c",
+                "sha256:501b671b639b9ca17ad303f8807deb1d0ff754d1dab106f2607d14b53cb0ff0b",
+                "sha256:5574574142364804423ab4428bd331a05c65f7ecfd31ac97c936f0c720fe6a53",
+                "sha256:6092239a772b3c6604be9e94b9ab4f0dacb7452e8ad299fd97eae0611355b679",
+                "sha256:71ff5c7632501c4f60edb8a24fd0a772e04c5bdca2856d978d04271b63666ef7",
+                "sha256:7dcf2ad14e25b05eda8bdd104f8c03a642a384aeefd25a5b51deac0826e646fa",
+                "sha256:8ca3a99f5a7443a6a8f83a5d8fcc11854b44e6907e92ba8640d8a8f7b9085e21",
+                "sha256:927da3b5710fb705aab173ad630b45a4a04c78e63dcd89411a065b2fe60e4770",
+                "sha256:94916d1ede67682638d3cc0feb10648ff14dc51fb7a7f147f4fedce78eaaea97",
+                "sha256:a3e5e5ca325527d312cdb12a4dab8b0459c458cad1c738c6f019d0d8d147081c",
+                "sha256:a7716a98f0b9b8f61ddb2bae7997daf546ac8fc594be6ba397f4bde7d76bfc62",
+                "sha256:acf10d1054de92af8d5bfc6620bb79b85f04c98214b4da7db77525bfa9fc2a89",
+                "sha256:de46ffb67e723975f5acab101c5235747af1e84fbbc89bf3533e2ea93fb26947",
+                "sha256:df428969154a9a4cd9748c7e6efd18432111fbea3d700f7376046c38c5e27081",
+                "sha256:f5ebf24b599caf466f9da8c4115398d663b2567b89e92f58a835e9da4f74669f",
+                "sha256:f79e45d5c122c4fb1fd54029bf1d475cecc05f4ed5b68136b0d6ec268bae68b6",
+                "sha256:f7a43097d143bd7846ffba6d2d8cd1cc97f233318dbd0f50a235ea01297a096b",
+                "sha256:fceb8271bc2fd3477094ca157c824e8ea840a7b393e89e766eea9a3b9ce7e0c6",
+                "sha256:ff919ceb40259f5332db43803aa6c22ff487e86036ce3921ae04b9185efc99a4"
+            ],
+            "index": "pypi",
+            "version": "==0.29"
         },
         "dnspython": {
             "hashes": [
@@ -500,9 +534,9 @@
         },
         "pycairo": {
             "hashes": [
-                "sha256:0f0a35ec923d87bc495f6753b1e540fd046d95db56a35250c44089fbce03b698"
+                "sha256:abd42a4c9c2069febb4c38fe74bfc4b4a9d3a89fea3bc2e4ba7baff7a20f783f"
             ],
-            "version": "==1.17.1"
+            "version": "==1.18.0"
         },
         "pycparser": {
             "hashes": [
@@ -551,10 +585,14 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:bc6c7146b91af3f567cf6daeaec360bc07d45ffec4cf5353f4d7a208ce7ca30a",
-                "sha256:d29593d8ebe7b57d6967b62494f8c72b03ac0262b1eed63826c6f788b3606401"
+                "sha256:40856e74d4987de5d01761a22d1621ae1c7f8774585acae358aa5c5936c6c90b",
+                "sha256:f353aab21fd474459d97b709e527b5571314ee5f067441dc9f88e33eecd96592"
             ],
-            "version": "==2.2.2"
+            "version": "==2.3.0"
+        },
+        "pyproj": {
+            "git": "https://github.com/jswhit/pyproj.git",
+            "ref": "882074864bb2e567a164624a3710907f34a4d478"
         },
         "python-dateutil": {
             "hashes": [

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -159,11 +159,10 @@ function sync_dependencies {
 		apt-get install -y libfreetype6-dev python3-dev pkg-config
 		if ! python3 -m pip --version; then
 			if apt-get install python3-pip; then
-				echo "Installed python3-pip via apt-get"
+				echo "INFO: Installed python3-pip via apt-get"
 			else
-				curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-				python3 get-pip.py
-				echo "Installed pip via get-pip.py"
+				curl https://bootstrap.pypa.io/get-pip.py | python3
+				echo "INFO: Installed pip via get-pip.py"
 			fi
 		fi
 		if [ -z "$KING_PHISHER_SKIP_CLIENT" ]; then

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -145,7 +145,8 @@ function sync_dependencies {
 			libpng-devel postgresql-devel python3-devel python3-pip \
 			libffi-devel openssl-devel
 		if [ -z "$KING_PHISHER_SKIP_CLIENT" ]; then
-			dnf install -y geos geos-devel gtksourceview3 vte3 gobject-introspection-devel
+			dnf install -y geos geos-devel gtksourceview3 gobject-introspection-devel
+			dnf install -y vte3
 		fi
 		# Fedora 23 is missing an rpm lib required, check to see if it has been installed.
 		if [ ! -d "$/usr/lib/rpm/redhat/redhat-hardened-cc1" ]; then
@@ -155,7 +156,16 @@ function sync_dependencies {
 		 [ "$LINUX_VERSION" == "Debian"  ] || \
 		 [ "$LINUX_VERSION" == "Kali"    ] || \
 		 [ "$LINUX_VERSION" == "Ubuntu"  ]; then
-		apt-get install -y libfreetype6-dev python3-dev python3-pip pkg-config
+		apt-get install -y libfreetype6-dev python3-dev pkg-config
+		if ! python3 -m pip --version; then
+			if apt-get install python3-pip; then
+				echo "Installed python3-pip via apt-get"
+			else
+				curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+				python3 get-pip.py
+				echo "Installed pip via get-pip.py"
+			fi
+		fi
 		if [ -z "$KING_PHISHER_SKIP_CLIENT" ]; then
 			if ! apt-get install -y gir1.2-gtk-3.0 gir1.2-gtksource-3.0 \
 				gir1.2-webkit-3.0 python3-cairo libgeos++-dev libgirepository1.0-dev \
@@ -200,6 +210,10 @@ function sync_dependencies {
 
 	echo "INFO: Synchronizing Python package dependencies from PyPi"
 	# six needs to be installed before requirements.txt for matplotlib
+	if ! python3 -m pip --version; then
+		echo "ERROR: Failed to find pip package for python3"
+		exit
+	fi
 	PIP_VERSION=$(pip --version)
 	python3 -m pip install --upgrade pip
 	# set pip back to python2 if python2 was default

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -146,6 +146,7 @@ function sync_dependencies {
 			libffi-devel openssl-devel
 		if [ -z "$KING_PHISHER_SKIP_CLIENT" ]; then
 			dnf install -y geos geos-devel gtksourceview3 gobject-introspection-devel
+			# vte3 not available in Fedora29. Try to install it in case its an older versions.
 			dnf install -y vte3
 		fi
 		# Fedora 23 is missing an rpm lib required, check to see if it has been installed.


### PR DESCRIPTION
This PR fixes the issues when installing issues on Ubuntu 18 Headless servers and Fedora 29.

For Ubuntu 18.04 Headless, python3-pip is not available via `apt-get`. The change here will first try to install `pip3` via `apt-get` if it fails then it will `wget` pypi `get-pip.py` install file and install pip via that method.

For Fedora 29 the `dnf` install packages where adjust for the client install. `vte3` is not available but not required so it was moved to its own line so it does not prevent the installation of other required packages. The next issue was they `pyproj` was not installing correctly due a [known issue](https://github.com/jswhit/pyproj/issues/136#issuecomment-410546181). To fix this issue, the latest `Cython` was added to the Pipefile, and `pyproj` is now install from github as the fix has not been pushed down to pypi.

Testing:
- [ ] `tools/install.sh` now installs on:
  - [ ] with `--skip-client` Ubuntu 18.04 server (headless)
  - [ ] Fedora 29
- [ ] unit tests run successful on both systems
- [ ] Server starts and runs successfully on both operating systems
- [ ] Client starts and runs on Fedora 29