### PR TITLE
Drop the old webkit install and reoder the new ones

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -168,7 +168,7 @@ function sync_dependencies {
 		fi
 		if [ -z "$KING_PHISHER_SKIP_CLIENT" ]; then
 			if ! apt-get install -y gir1.2-gtk-3.0 gir1.2-gtksource-3.0 \
-				gir1.2-webkit-3.0 python3-cairo libgeos++-dev libgirepository1.0-dev \
+				python3-cairo libgeos++-dev libgirepository1.0-dev \
 				libgtk-3-dev libpq-dev python3-gi python3-gi-cairo libpq-dev; then
 					echo "ERROR: Failed to install dependencies with apt-get"
 					exit
@@ -188,10 +188,10 @@ function sync_dependencies {
 				fi
 			fi
 
-			if apt-get install -y gir1.2-webkit2-3.0 &> /dev/null; then
-				echo "INFO: Successfully installed gir1.2-webkit2-3.0 with apt-get"
-			elif apt-get install -y gir1.2-webkit2-4.0 &> /dev/null; then
+			if apt-get install -y gir1.2-webkit2-4.0 &> /dev/null; then
 				echo "INFO: Successfully installed gir1.2-webkit2-4.0 with apt-get"
+			elif apt-get install -y gir1.2-webkit2-3.0 &> /dev/null; then
+				echo "INFO: Successfully installed gir1.2-webkit2-3.0 with apt-get"
 			else
 				echo "ERROR: Failed to install gir1.2-webkit2 3.0 or 4.0 with apt-get"
 			fi


### PR DESCRIPTION
This PR makes the following two changes to the install script.

1. Removes the old `gir1.2-webkit-3.0` package from being installed (which I'm guessing isn't available in newer Kali installs)
1. Switches to favor installing `gir1.2-webkit2-4.0` over `gir1.2-webkit2-3.0`

@wolfthefallen can you check if we have any old but still supported version of Linux that need `gir1.2-webkit-3.0`?

## Testing
- [ ] Running `sudo tools/install.sh --update` works as expected on an Ubuntu / Kali system
    * Specifically if `gir1.2-webkit2-4.0` is installed, that King Phisher is able to use it

Fixes #330