### PR TITLE
Url autocomplete

### DIFF
--- a/data/client/king_phisher/queries/get_site_templates.graphql
+++ b/data/client/king_phisher/queries/get_site_templates.graphql
@@ -1,5 +1,5 @@
 # retrieve information of all site templates
-query getsiteTemplates {
+query getSiteTemplates {
   siteTemplates {
     edges {
       node {

--- a/data/client/king_phisher/queries/get_site_templates.graphql
+++ b/data/client/king_phisher/queries/get_site_templates.graphql
@@ -1,0 +1,18 @@
+# retrieve information of all site templates
+query getsiteTemplates {
+  siteTemplates {
+    edges {
+      node {
+        created
+        hostname
+        path
+        metadata {
+          authors
+          classifiers
+          description
+          pages
+        }
+      }
+    }
+  }
+}

--- a/docs/source/king_phisher/client/gui_utilities.rst
+++ b/docs/source/king_phisher/client/gui_utilities.rst
@@ -20,6 +20,8 @@ Functions
 
 .. autofunction:: glib_idle_add_wait
 
+.. autofunction:: glib_idle_add_store_extend
+
 .. autofunction:: gobject_get_value
 
 .. autofunction:: gobject_set_value

--- a/king_phisher/client/application.py
+++ b/king_phisher/client/application.py
@@ -552,7 +552,17 @@ class KingPhisherClientApplication(_Gtk_Application):
 
 	def load_server_config(self):
 		"""Load the necessary values from the server's configuration."""
-		self.config['server_config'] = self.rpc('config/get', ['server.require_id', 'server.secret_id', 'server.tracking_image', 'server.web_root'])
+		self.config['server_config'] = self.rpc(
+			'config/get',
+			[
+				'server.require_id',
+				'server.secret_id',
+				'server.tracking_image',
+				'server.web_root',
+				'server.addresses',
+				'server.vhost_directories'
+			]
+		)
 		return
 
 	def load_style_css(self, css_file):

--- a/king_phisher/client/gui_utilities.py
+++ b/king_phisher/client/gui_utilities.py
@@ -102,6 +102,29 @@ def which_glade():
 	"""
 	return find.data_file(os.environ.get('KING_PHISHER_GLADE_FILE', 'king-phisher-client.ui'))
 
+def _store_extend(store, things, clear=False):
+	if clear:
+		store.clear()
+	for thing in things:
+		store.append(thing)
+
+def glib_idle_add_store_extend(store, things, clear=False, wait=False):
+	"""
+	Extend a GTK store object (either :py:class:`Gtk.ListStore` or :py:class:`Gtk.TreeStore`)
+	object using :py:func:`GLib.idle_add`.
+	This function is suitable for use in non-main GUI threads for synchronizing data.
+
+	note** regardless of *wait*, None is returned
+
+	:param store: The GTK storage object to add *things* to.
+	:type store: :py:class:`Gtk.ListStore`, :py:class:`Gtk.TreeStore`
+	:param tuple things: The array of things to add to *store*.
+	:param bool clear: Whether or not to clear the storage object before adding *things* to it.
+	:param bool wait: Whether or not to wait for the operation to complete before returning.
+	"""
+	idle_add = glib_idle_add_wait if wait else glib_idle_add_once
+	idle_add(_store_extend, store, things, clear)
+
 def glib_idle_add_once(function, *args, **kwargs):
 	"""
 	Execute *function* in the main GTK loop using :py:func:`GLib.idle_add`


### PR DESCRIPTION
Using the new graphql call to fetch webpage `.metadata.yml` file information. This PR takes that information to build valid urls available to the King Phisher server, and adds it to list that the entry web server url can reference to present to the end user for selection.

To test:
set up king phisher and place in the .metadata.yml in to your web directories to reference the landing pages you wish.

log in with king phisher client.. select campaign, 
* type in `h` all options should populate.
* type in the first couple of characters of a hostname, its options should populate

** if no hostname is available, it checks addresses available to the king phisher server and if it is not `0.0.0.0` it will present that as an option, else it will not populate anything for that landing page, as no valid uri could be made.