### PR TITLE
Updated CampaignAssistant

### DIFF
--- a/data/client/king_phisher/king-phisher-client.ui
+++ b/data/client/king_phisher/king-phisher-client.ui
@@ -1281,6 +1281,8 @@ Spencer McIntyre</property>
                             <property name="tooltip_text" translatable="yes">Destination folder for KPM contents.</property>
                             <property name="hexpand">True</property>
                             <property name="editable">False</property>
+                            <property name="primary_icon_stock">gtk-directory</property>
+                            <signal name="backspace" handler="signal_kpm_dest_folder" swapped="no"/>
                           </object>
                           <packing>
                             <property name="left_attach">0</property>
@@ -1308,8 +1310,10 @@ Spencer McIntyre</property>
                             <property name="hexpand">True</property>
                             <property name="editable">False</property>
                             <property name="invisible_char">●</property>
+                            <property name="primary_icon_stock">gtk-file</property>
                             <property name="primary_icon_activatable">False</property>
                             <property name="secondary_icon_activatable">False</property>
+                            <signal name="backspace" handler="signal_kpm_file_clear" swapped="no"/>
                           </object>
                           <packing>
                             <property name="left_attach">0</property>
@@ -1335,7 +1339,7 @@ Spencer McIntyre</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
-                            <signal name="clicked" handler="signal_kpm_dest_folder" swapped="no"/>
+                            <signal name="clicked" handler="signal_kpm_dest_folder_clicked" swapped="no"/>
                           </object>
                           <packing>
                             <property name="left_attach">1</property>

--- a/data/client/king_phisher/king-phisher-client.ui
+++ b/data/client/king_phisher/king-phisher-client.ui
@@ -1203,13 +1203,181 @@ Spencer McIntyre</property>
         </child>
       </object>
       <packing>
-        <property name="title" translatable="yes">Advertised URLS</property>
+        <property name="title" translatable="yes">Target URL</property>
         <property name="complete">True</property>
         <property name="has_padding">False</property>
       </packing>
     </child>
     <child>
       <object class="GtkBox" id="CampaignAssistant.page7">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="margin_top">5</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">10</property>
+        <child>
+          <object class="GtkLabel" id="CampaignAssistant.label_kpm_top_level">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">center</property>
+            <property name="label" translatable="yes">KPM Import</property>
+            <attributes>
+              <attribute name="weight" value="bold"/>
+              <attribute name="scale" value="1.5"/>
+            </attributes>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkGrid" id="grid8">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="margin_left">3</property>
+            <property name="margin_right">3</property>
+            <property name="row_spacing">3</property>
+            <property name="column_spacing">10</property>
+            <property name="row_homogeneous">True</property>
+            <child>
+              <object class="GtkFrame" id="CampaignAssistant.frame_kpm_import">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label_xalign">0</property>
+                <property name="shadow_type">none</property>
+                <child>
+                  <object class="GtkAlignment">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="top_padding">5</property>
+                    <property name="bottom_padding">5</property>
+                    <property name="left_padding">12</property>
+                    <property name="right_padding">5</property>
+                    <child>
+                      <object class="GtkGrid" id="CampaignAssistant.grid_credential_validation_regexs1">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="row_spacing">3</property>
+                        <property name="column_spacing">3</property>
+                        <child>
+                          <object class="GtkLabel" id="CampaignAssistant.label_kpm_file">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="label" translatable="yes">Message Configuration File</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">0</property>
+                            <property name="width">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkEntry" id="CampaignAssistant.entry_kpm_dest_folder">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="tooltip_text" translatable="yes">Destination folder for KPM contents.</property>
+                            <property name="hexpand">True</property>
+                            <property name="editable">False</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">3</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="CampaignAssistant.label_kpm_dest_folder">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="label" translatable="yes">Destination Folder</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">2</property>
+                            <property name="width">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkEntry" id="CampaignAssistant.entry_kpm_file">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="tooltip_text" translatable="yes">File path to KPM file</property>
+                            <property name="hexpand">True</property>
+                            <property name="editable">False</property>
+                            <property name="invisible_char">●</property>
+                            <property name="primary_icon_activatable">False</property>
+                            <property name="secondary_icon_activatable">False</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="CampaignAssistant.button_select_kpm_file">
+                            <property name="label" translatable="yes">Select</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <signal name="clicked" handler="signal_kpm_select_clicked" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="CampaignAssistant.button_select_kpm_dest_folder">
+                            <property name="label" translatable="yes">Select</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <signal name="clicked" handler="signal_kpm_dest_folder" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">3</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child type="label">
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">KPM settings</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="title" translatable="yes">Import KPM</property>
+        <property name="complete">True</property>
+        <property name="has_padding">False</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkBox" id="CampaignAssistant.page8">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="margin_left">5</property>
@@ -1280,39 +1448,10 @@ Spencer McIntyre</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <child>
-              <object class="GtkLabel" id="CampaignAssistant.label_import_kpm">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">3</property>
-                <property name="margin_right">3</property>
-                <property name="margin_top">3</property>
-                <property name="margin_bottom">3</property>
-                <property name="label" translatable="yes">Import Message Configuration settings:</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
+              <placeholder/>
             </child>
             <child>
-              <object class="GtkButton" id="CampaignAssistant.button_import_kpm">
-                <property name="label" translatable="yes">Import</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="tooltip_text" translatable="yes">Import message configuration settings to quickly configure phishing setting for the campaign.</property>
-                <property name="margin_left">3</property>
-                <property name="margin_right">3</property>
-                <property name="margin_top">3</property>
-                <property name="margin_bottom">3</property>
-                <signal name="clicked" handler="signal_kpm_import_clicked" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
+              <placeholder/>
             </child>
           </object>
           <packing>
@@ -1328,9 +1467,6 @@ Spencer McIntyre</property>
         <property name="complete">True</property>
         <property name="has_padding">False</property>
       </packing>
-    </child>
-    <child>
-      <placeholder/>
     </child>
     <child>
       <placeholder/>

--- a/data/client/king_phisher/king-phisher-client.ui
+++ b/data/client/king_phisher/king-phisher-client.ui
@@ -1282,7 +1282,7 @@ Spencer McIntyre</property>
                             <property name="hexpand">True</property>
                             <property name="editable">False</property>
                             <property name="primary_icon_stock">gtk-directory</property>
-                            <signal name="backspace" handler="signal_kpm_dest_folder" swapped="no"/>
+                            <signal name="backspace" handler="signal_kpm_entry_clear" swapped="no"/>
                           </object>
                           <packing>
                             <property name="left_attach">0</property>
@@ -1313,7 +1313,7 @@ Spencer McIntyre</property>
                             <property name="primary_icon_stock">gtk-file</property>
                             <property name="primary_icon_activatable">False</property>
                             <property name="secondary_icon_activatable">False</property>
-                            <signal name="backspace" handler="signal_kpm_file_clear" swapped="no"/>
+                            <signal name="backspace" handler="signal_kpm_entry_clear" swapped="no"/>
                           </object>
                           <packing>
                             <property name="left_attach">0</property>
@@ -1362,9 +1362,6 @@ Spencer McIntyre</property>
                 <property name="left_attach">0</property>
                 <property name="top_attach">0</property>
               </packing>
-            </child>
-            <child>
-              <placeholder/>
             </child>
           </object>
           <packing>

--- a/data/client/king_phisher/king-phisher-client.ui
+++ b/data/client/king_phisher/king-phisher-client.ui
@@ -946,7 +946,279 @@ Spencer McIntyre</property>
         <property name="orientation">vertical</property>
         <property name="spacing">10</property>
         <child>
-          <object class="GtkBox" id="box16">
+          <object class="GtkLabel" id="CampaignAssistant.label_webserver_url">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="valign">start</property>
+            <property name="margin_top">3</property>
+            <property name="margin_bottom">3</property>
+            <property name="label" translatable="yes">Web Server URL</property>
+            <property name="justify">fill</property>
+            <property name="ellipsize">start</property>
+            <property name="single_line_mode">True</property>
+            <attributes>
+              <attribute name="weight" value="bold"/>
+              <attribute name="scale" value="1.5"/>
+            </attributes>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <child>
+              <object class="GtkLabel" id="CampaignAssistant.label_domain_filter">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Domain</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkEntry" id="CampaignAssistant.entry_domain_filter">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="tooltip_text" translatable="yes">Domain to filter url list by</property>
+                <property name="hexpand">True</property>
+                <property name="primary_icon_tooltip_text" translatable="yes">Domain to filter by</property>
+                <property name="placeholder_text" translatable="yes">foo.bar</property>
+                <signal name="changed" handler="signal_url_entry_change" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkScrolledWindow" id="CampaignAssistant.url_scrolled_window">
+            <property name="width_request">425</property>
+            <property name="height_request">150</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="margin_top">3</property>
+            <property name="margin_bottom">3</property>
+            <property name="shadow_type">in</property>
+            <child>
+              <object class="GtkTreeView" id="CampaignAssistant.treeview_url_selector">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="activate_on_single_click">True</property>
+                <signal name="row-activated" handler="signal_url_treeview_row_activated" swapped="no"/>
+                <child internal-child="selection">
+                  <object class="GtkTreeSelection" id="CampaignAssistant.treeselection_url_selector"/>
+                </child>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkExpander" id="CampaignAssistant.expander_url_information">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="expanded">True</property>
+            <property name="resize_toplevel">True</property>
+            <child>
+              <object class="GtkGrid">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkLabel" id="CampaignAssistant.label_url">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="valign">center</property>
+                    <property name="margin_top">3</property>
+                    <property name="margin_bottom">3</property>
+                    <property name="label" translatable="yes">URL:</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="CampaignAssistant.label_authors">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="valign">center</property>
+                    <property name="margin_top">3</property>
+                    <property name="margin_bottom">3</property>
+                    <property name="label" translatable="yes">Author(s):</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="CampaignAssistant.label_classifiers">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="valign">center</property>
+                    <property name="margin_top">3</property>
+                    <property name="margin_bottom">3</property>
+                    <property name="label" translatable="yes">Classifiers:</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">3</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="CampaignAssistant.label_description">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="valign">center</property>
+                    <property name="margin_top">3</property>
+                    <property name="margin_bottom">3</property>
+                    <property name="label" translatable="yes">Description:</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">4</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="CampaignAssistant.label_created">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="valign">center</property>
+                    <property name="margin_top">3</property>
+                    <property name="margin_bottom">3</property>
+                    <property name="label" translatable="yes">Created:</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="CampaignAssistant.label_info_url">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="valign">center</property>
+                    <property name="margin_top">3</property>
+                    <property name="margin_bottom">3</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="CampaignAssistant.label_info_authors">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="valign">center</property>
+                    <property name="margin_top">3</property>
+                    <property name="margin_bottom">3</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="CampaignAssistant.label_info_created">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="valign">center</property>
+                    <property name="margin_top">3</property>
+                    <property name="margin_bottom">3</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="CampaignAssistant.label_info_description">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="valign">center</property>
+                    <property name="margin_top">3</property>
+                    <property name="margin_bottom">3</property>
+                    <property name="label" translatable="yes">label</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">4</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkListBox" id="CampaignAssistant.listbox_domain_info_classifiers">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">3</property>
+                  </packing>
+                </child>
+              </object>
+            </child>
+            <child type="label">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">URL Information</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">4</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="title" translatable="yes">Advertised URLS</property>
+        <property name="complete">True</property>
+        <property name="has_padding">False</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkBox" id="CampaignAssistant.page7">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="margin_left">5</property>
+        <property name="margin_right">10</property>
+        <property name="margin_top">5</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">10</property>
+        <child>
+          <object class="GtkBox" id="box21">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="halign">center</property>
@@ -1003,6 +1275,52 @@ Spencer McIntyre</property>
             <property name="position">1</property>
           </packing>
         </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <child>
+              <object class="GtkLabel" id="CampaignAssistant.label_import_kpm">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">3</property>
+                <property name="margin_right">3</property>
+                <property name="margin_top">3</property>
+                <property name="margin_bottom">3</property>
+                <property name="label" translatable="yes">Import Message Configuration settings:</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="CampaignAssistant.button_import_kpm">
+                <property name="label" translatable="yes">Import</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="tooltip_text" translatable="yes">Import message configuration settings to quickly configure phishing setting for the campaign.</property>
+                <property name="margin_left">3</property>
+                <property name="margin_right">3</property>
+                <property name="margin_top">3</property>
+                <property name="margin_bottom">3</property>
+                <signal name="clicked" handler="signal_kpm_import_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
       </object>
       <packing>
         <property name="page_type">confirm</property>
@@ -1010,12 +1328,6 @@ Spencer McIntyre</property>
         <property name="complete">True</property>
         <property name="has_padding">False</property>
       </packing>
-    </child>
-    <child>
-      <placeholder/>
-    </child>
-    <child>
-      <placeholder/>
     </child>
     <child>
       <placeholder/>

--- a/data/client/king_phisher/queries/get_site_template.graphql
+++ b/data/client/king_phisher/queries/get_site_template.graphql
@@ -1,4 +1,4 @@
-# retrieve information of all site templates
+# retrieve information for site templates by hostname
 query getSiteTemplates($hostname: String!) {
   siteTemplates(hostname: $hostname) {
     edges {

--- a/data/client/king_phisher/queries/get_site_template.graphql
+++ b/data/client/king_phisher/queries/get_site_template.graphql
@@ -1,0 +1,18 @@
+# retrieve information of all site templates
+query getSiteTemplates($hostname: String!) {
+  siteTemplates(hostname: $hostname) {
+    edges {
+      node {
+        created
+        hostname
+        path
+        metadata {
+          authors
+          classifiers
+          description
+          pages
+        }
+      }
+    }
+  }
+}

--- a/data/client/king_phisher/queries/get_site_templates.graphql
+++ b/data/client/king_phisher/queries/get_site_templates.graphql
@@ -1,4 +1,4 @@
-# retrieve information of all site templates
+# retrieve information for all site templates
 query getSiteTemplates {
   siteTemplates {
     edges {

--- a/docs/source/king_phisher/client/gui_utilities.rst
+++ b/docs/source/king_phisher/client/gui_utilities.rst
@@ -58,6 +58,8 @@ Functions
 
 .. autofunction:: gtk_widget_destroy_children
 
+.. autofunction:: set_listbox_classifiers
+
 .. autofunction:: show_dialog
 
 .. autofunction:: show_dialog_exc_socket_error

--- a/king_phisher/client/assistants/campaign.py
+++ b/king_phisher/client/assistants/campaign.py
@@ -66,35 +66,17 @@ _KpmImport = collections.namedtuple('KpmImport', (
 class KpmImport(object):
 
 	def __init__(self):
-		self._target_file = None
-		self._dest_folder = None
+		self.target_file = None
+		self.dest_folder = None
 
 	def __bool__(self):
-		if not self._dest_folder or self._target_file:
+		if not self.dest_folder or not self.target_file:
 			return False
-		if not os.path.isfile(self._target_file):
+		if not os.path.isfile(self.target_file):
 			return False
-		if not os.path.isdir(self._dest_folder):
+		if not os.path.isdir(self.dest_folder):
 			return False
 		return True
-
-	@property
-	def target_file(self):
-		return self._target_file
-
-	@target_file.setter
-	def target_file(self, target_file):
-		if os.path.isfile(target_file):
-			self._target_file = target_file
-
-	@property
-	def dest_folder(self):
-		return self._dest_folder
-
-	@dest_folder.setter
-	def dest_folder(self, dest_folder):
-		if os.path.isdir(dest_folder):
-			self._dest_folder = dest_folder
 
 class CampaignAssistant(gui_utilities.GladeGObject):
 	"""
@@ -261,8 +243,12 @@ class CampaignAssistant(gui_utilities.GladeGObject):
 			return False
 		self._import_kpm.target_file = response['target_path']
 		self.gobjects['entry_kpm_file'].set_text(self._import_kpm.target_file)
+		if not self._import_kpm.dest_folder:
+			self.assistant.set_page_complete(self.assistant.get_nth_page(self.assistant.get_current_page()), False)
+		else:
+			self.assistant.set_page_complete(self.assistant.get_nth_page(self.assistant.get_current_page()), True)
 
-	def signal_kpm_dest_folder(self, _):
+	def signal_kpm_dest_folder_clicked(self, _):
 		dialog = extras.FileChooserDialog('Destination Directory', self.parent)
 		response = dialog.run_quick_select_directory()
 		dialog.destroy()
@@ -270,24 +256,26 @@ class CampaignAssistant(gui_utilities.GladeGObject):
 			return False
 		self._import_kpm.dest_folder = response['target_path']
 		self.gobjects['entry_kpm_dest_folder'].set_text(self._import_kpm.dest_folder)
+		if not self._import_kpm.target_file:
+			self.assistant.set_page_complete(self.assistant.get_nth_page(self.assistant.get_current_page()), False)
+		else:
+			self.assistant.set_page_complete(self.assistant.get_nth_page(self.assistant.get_current_page()), True)
 
-	def signal_kpm_import_clicked(self, _):
-		dialog = extras.FileChooserDialog('Import Message Configuration', self.parent)
-		dialog.quick_add_filter('King Phisher Message Files', '*.kpm')
-		dialog.quick_add_filter('All Files', '*')
-		response = dialog.run_quick_open()
-		dialog.destroy()
-		if not response:
-			return False
-		kpm_target_file = response['target_path']
+	def signal_kpm_file_clear(self, _):
+		self.gobjects['entry_kpm_file'].set_text('')
+		self._import_kpm.target_file = None
+		if not self._import_kpm.dest_folder:
+			self.assistant.set_page_complete(self.assistant.get_nth_page(self.assistant.get_current_page()), True)
+		else:
+			self.assistant.set_page_complete(self.assistant.get_nth_page(self.assistant.get_current_page()), False)
 
-		dialog = extras.FileChooserDialog('Destination Directory', self.parent)
-		response = dialog.run_quick_select_directory()
-		dialog.destroy()
-		if not response:
-			self._import_kpm = None
-			return False
-		self._import_kpm = _KpmImport(file_path=kpm_target_file, dir_path=response['target_path'])
+	def signal_kpm_dest_folder(self, _):
+		self.gobjects['entry_kpm_dest_folder'].set_text('')
+		self._import_kpm.dest_folder = None
+		if not self._import_kpm.target_file:
+			self.assistant.set_page_complete(self.assistant.get_nth_page(self.assistant.get_current_page()), True)
+		else:
+			self.assistant.set_page_complete(self.assistant.get_nth_page(self.assistant.get_current_page()), False)
 
 	def _set_comboboxes(self):
 		"""Set up all the comboboxes and load the data for their models."""

--- a/king_phisher/client/gui_utilities.py
+++ b/king_phisher/client/gui_utilities.py
@@ -39,6 +39,7 @@ import logging
 import os
 import socket
 import threading
+import xml.sax.saxutils as saxutils
 
 from king_phisher import find
 from king_phisher import utilities
@@ -512,6 +513,35 @@ def gtk_widget_destroy_children(widget):
 	"""
 	for child in widget.get_children():
 		child.destroy()
+
+def set_listbox_classifiers(label, listbox, classifiers):
+	"""
+	Formats and adds classifiers to a listbox.
+	If no classifiers, it hides the label and listbox.
+
+	:param label: Gtk Label associated with the listbox
+	:type label: :py:class:`Gtk.label`
+	:param listbox: Gtk Listbox to put the classifiers in.
+	:type listbox: :py:class:`Gtk.listbox`
+	:param list classifiers: List of classifiers to add to the Gtk Listbox
+	"""
+	gtk_widget_destroy_children(listbox)
+
+	if not classifiers:
+		label.set_property('visible', False)
+		listbox.set_property('visible', False)
+		return
+
+	label.set_property('visible', True)
+	listbox.set_property('visible', True)
+	for classifier in classifiers:
+		label = Gtk.Label()
+		label.set_markup("<span font=\"smaller\"><tt>{0}</tt></span>".format(saxutils.escape(classifier)))
+		label.set_property('halign', Gtk.Align.START)
+		label.set_property('use-markup', True)
+		label.set_property('valign', Gtk.Align.START)
+		label.set_property('visible', True)
+		listbox.add(label)
 
 def show_dialog(message_type, message, parent, secondary_text=None, message_buttons=Gtk.ButtonsType.OK, use_markup=False, secondary_use_markup=False):
 	"""

--- a/king_phisher/client/tabs/mail.py
+++ b/king_phisher/client/tabs/mail.py
@@ -975,6 +975,7 @@ class MailSenderConfigurationTab(gui_utilities.GladeGObject):
 		else:
 			self.config['mailer.company_name'] = campaign['company']['name']
 		self.gobjects['entry_company_name'].set_text(self.config['mailer.company_name'] or '')
+		self.gobjects['entry_webserver_url'].set_text(self.config['mailer.webserver_url'] or '')
 
 	def _update_target_count(self):
 		if not hasattr(self, 'target_type'):
@@ -1243,6 +1244,7 @@ class MailSenderTab(_GObject_GObject):
 		context_id = self.status_bar.get_context_id('campaign name')
 		self.status_bar.pop(context_id)
 		self.status_bar.push(context_id, self.config['campaign_name'])
+		#self.go
 
 	def signal_notebook_switch_page(self, notebook, current_page, index):
 		previous_page = notebook.get_nth_page(self.last_page_id)

--- a/king_phisher/client/tabs/mail.py
+++ b/king_phisher/client/tabs/mail.py
@@ -936,6 +936,8 @@ class MailSenderConfigurationTab(gui_utilities.GladeGObject):
 
 	def _set_entry_completion_list_tsafe(self):
 		gui_utilities.glib_idle_add_once(self._url_list_store.clear)
+		if not self.application.rpc:
+			return
 		url_information = self.application.rpc.graphql_find_file('get_site_templates.graphql')
 		if not url_information:
 			return
@@ -1244,7 +1246,6 @@ class MailSenderTab(_GObject_GObject):
 		context_id = self.status_bar.get_context_id('campaign name')
 		self.status_bar.pop(context_id)
 		self.status_bar.push(context_id, self.config['campaign_name'])
-		#self.go
 
 	def signal_notebook_switch_page(self, notebook, current_page, index):
 		previous_page = notebook.get_nth_page(self.last_page_id)

--- a/king_phisher/client/widget/completion_providers.py
+++ b/king_phisher/client/widget/completion_providers.py
@@ -30,9 +30,11 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+import ipaddress
 import logging
 import os
 import re
+import urllib
 
 from king_phisher import find
 from king_phisher import its

--- a/king_phisher/client/windows/plugin_manager.py
+++ b/king_phisher/client/windows/plugin_manager.py
@@ -619,26 +619,11 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 		self.gobjects['label_plugin_info_description'].set_text(plugin['description'])
 		self._set_info_plugin_homepage_url(plugin['homepage'])
 		self._set_info_plugin_reference_urls(plugin.get('reference_urls', []))
-		self._set_info_plugin_classifiers(plugin.get('classifiers', []))
-
-	def _set_info_plugin_classifiers(self, classifiers):
-		label = self.gobjects['label_plugin_info_for_classifiers']
-		listbox = self.gobjects['listbox_plugin_info_classifiers']
-		gui_utilities.gtk_widget_destroy_children(listbox)
-		if not classifiers:
-			label.set_property('visible', False)
-			listbox.set_property('visible', False)
-			return
-		label.set_property('visible', True)
-		listbox.set_property('visible', True)
-		for classifier in classifiers:
-			label = Gtk.Label()
-			label.set_markup("<span font=\"smaller\"><tt>{0}</tt></span>".format(saxutils.escape(classifier)))
-			label.set_property('halign', Gtk.Align.START)
-			label.set_property('use-markup', True)
-			label.set_property('valign', Gtk.Align.START)
-			label.set_property('visible', True)
-			listbox.add(label)
+		gui_utilities.set_listbox_classifiers(
+			self.gobjects['label_plugin_info_for_classifiers'],
+			self.gobjects['listbox_plugin_info_classifiers'],
+			plugin.get('classifiers', [])
+		)
 
 	def _set_info_plugin_error(self, model_instance):
 		id_ = _ModelNamedRow(*model_instance).id


### PR DESCRIPTION
Updated Campaign Assistant to provide advertised URLs from the king-phisher server and the ability to import KPM.

This PR adds one tab to the Campaign Assistant that displays the information from advertised landing pages from the King Phisher Server for the user to select when the are creating or configuring the campaign. In addition on the finalize page the user now has the option to import a campaign to quickly configure their message settings.

Now when you finalize on the Campaign Assistant, it will now emit `campaign-change` forcing a load of all the message settings that get set during the new functions in cooperated into the work flow. 

Test Cases:
- [ ] You can see the new tab `Advertised URLs`
  - [ ] If you select an entry it will load in the message configuration window when you close the Assistant
- [ ] Last page has a `Import` button to allow the user to import a KPM file
  - [ ] You select the KPM file and destination folder but does not load until assistant is 'Applied`
  - [ ] If you select an Advertised URL it over writes the URL supplied with the KPM file.
- [ ] GUI on the new tab is in line and flows with the rest of the King Phish GUI
- [ ] Labels and tool tips are clear and understandable
