### PR TITLE
Access method

### DIFF
--- a/docs/source/king_phisher/server/fs_utilities.rst
+++ b/docs/source/king_phisher/server/fs_utilities.rst
@@ -11,3 +11,5 @@ Functions
 ---------
 
 .. autofunction:: chown
+
+.. autofunction:: access

--- a/docs/source/king_phisher/server/fs_utilities.rst
+++ b/docs/source/king_phisher/server/fs_utilities.rst
@@ -10,6 +10,8 @@ the application.
 Functions
 ---------
 
+.. autofunction:: access
+
 .. autofunction:: chown
 
-.. autofunction:: access
+

--- a/king_phisher/server/fs_utilities.py
+++ b/king_phisher/server/fs_utilities.py
@@ -33,13 +33,12 @@
 import grp
 import os
 import pwd
+import stat
 
-import collections
-import king_phisher.server.pylibc as pylibc
 import smoke_zephyr.utilities
 
 from king_phisher import constants
-from os import stat
+import king_phisher.server.pylibc as pylibc
 
 def chown(path, user=None, group=constants.AUTOMATIC, recursive=True):
 	"""
@@ -115,7 +114,6 @@ def access(path, mode, user=None, group=constants.AUTOMATIC):
 	if isinstance(user, str):
 		user_info = pylibc.getpwnam(user)
 		file_info = os.stat(path)
-		raise ValueError('hi :)')
 		if mode == 'R_OK':
 			user_permissions = stat.S_IRUSR
 			group_permissions = stat.S_IRGRP

--- a/king_phisher/server/fs_utilities.py
+++ b/king_phisher/server/fs_utilities.py
@@ -38,7 +38,7 @@ import stat
 import smoke_zephyr.utilities
 
 from king_phisher import constants
-import king_phisher.server.pylibc as pylibc
+from king_phisher.server import pylibc
 
 def chown(path, user=None, group=constants.AUTOMATIC, recursive=True):
 	"""

--- a/king_phisher/server/fs_utilities.py
+++ b/king_phisher/server/fs_utilities.py
@@ -83,3 +83,6 @@ def chown(path, user=None, group=constants.AUTOMATIC, recursive=True):
 		iterator = (path,)
 	for path in iterator:
 		os.chown(path, user, group)
+
+def access():
+	pass

--- a/king_phisher/server/fs_utilities.py
+++ b/king_phisher/server/fs_utilities.py
@@ -85,4 +85,8 @@ def chown(path, user=None, group=constants.AUTOMATIC, recursive=True):
 		os.chown(path, user, group)
 
 def access():
+	"""
+	
+	:return:
+	"""
 	pass


### PR DESCRIPTION
# Access Method

## Description
There seems to be a significant need for determining the permissions a user has
on files outside of the current user. Access acts as a wrapper for **os.access** by
extending the ability to specify a user and/or group along with a file to test permissions against.

## Requirements
- [ ] Allow users to specify a file to test against
- [ ] Allow users to specify a mode to test against (R_OK, W_OK, X_OK)
- [ ] Enable user to specify either a user *or* a group to test against.


## Run / test configuration
* **Run Config**
  * access(*test-file*, *mode*, user=*user*, group=*group*)
  * Either user or group must be specified only one can be left as default.
* **Owner Tests**
  * Make a user the owner: `chown <user> test-file`
    * Owner and read `chmod u+r test-file`
    * Owner and write `chmod u+w test-file`
    * Owner and execute `chmod u+x test-file`
* **User's Group Tests & All group Test**
  * Make a user's group the owner: `chown :<user's-group> test-file`
  * To test other groups other than the user's group, enumerate a group they're apart of <br> (e.g, adm) and add that group to the file: `chown :<enumerated-group> test-file`
    * Group and read `chmod g+r test-file`
    * Group and write `chmod g+w test-file`
    * Group and execute `chmod g+x test-file`
* **Other Tests**
  * Other and read `chmod o+r test-file`
  * Other and write `chmod o+w test-file`
  * Other and execute `chmod o+x test-file`
