### PR TITLE
SSH Forwading update

### DIFF
--- a/docs/source/king_phisher/server/fs_utilities.rst
+++ b/docs/source/king_phisher/server/fs_utilities.rst
@@ -11,3 +11,5 @@ Functions
 ---------
 
 .. autofunction:: chown
+
+.. autofunction:: access

--- a/docs/source/king_phisher/server/fs_utilities.rst
+++ b/docs/source/king_phisher/server/fs_utilities.rst
@@ -10,6 +10,8 @@ the application.
 Functions
 ---------
 
+.. autofunction:: access
+
 .. autofunction:: chown
 
-.. autofunction:: access
+

--- a/king_phisher/server/fs_utilities.py
+++ b/king_phisher/server/fs_utilities.py
@@ -33,13 +33,12 @@
 import grp
 import os
 import pwd
+import stat
 
-import collections
-import king_phisher.server.pylibc as pylibc
 import smoke_zephyr.utilities
 
 from king_phisher import constants
-from os import stat
+import king_phisher.server.pylibc as pylibc
 
 def chown(path, user=None, group=constants.AUTOMATIC, recursive=True):
 	"""
@@ -115,7 +114,6 @@ def access(path, mode, user=None, group=constants.AUTOMATIC):
 	if isinstance(user, str):
 		user_info = pylibc.getpwnam(user)
 		file_info = os.stat(path)
-		raise ValueError('hi :)')
 		if mode == 'R_OK':
 			user_permissions = stat.S_IRUSR
 			group_permissions = stat.S_IRGRP

--- a/king_phisher/server/fs_utilities.py
+++ b/king_phisher/server/fs_utilities.py
@@ -38,7 +38,7 @@ import stat
 import smoke_zephyr.utilities
 
 from king_phisher import constants
-import king_phisher.server.pylibc as pylibc
+from king_phisher.server import pylibc
 
 def chown(path, user=None, group=constants.AUTOMATIC, recursive=True):
 	"""

--- a/king_phisher/server/fs_utilities.py
+++ b/king_phisher/server/fs_utilities.py
@@ -83,3 +83,6 @@ def chown(path, user=None, group=constants.AUTOMATIC, recursive=True):
 		iterator = (path,)
 	for path in iterator:
 		os.chown(path, user, group)
+
+def access():
+	pass

--- a/king_phisher/server/fs_utilities.py
+++ b/king_phisher/server/fs_utilities.py
@@ -85,4 +85,8 @@ def chown(path, user=None, group=constants.AUTOMATIC, recursive=True):
 		os.chown(path, user, group)
 
 def access():
+	"""
+	
+	:return:
+	"""
 	pass

--- a/king_phisher/ssh_forward.py
+++ b/king_phisher/ssh_forward.py
@@ -153,8 +153,10 @@ class SSHTCPForwarder(threading.Thread):
 			else:
 				self.logger.warning('failed to identify the user specified key for ssh authentication')
 
-		if not self.__connected and len(agent_keys) == 1:
-			self.__try_connect(look_for_keys=False, pkey=agent_keys[0])
+		if not self.__connected and agent_keys:
+			for key in agent_keys:
+				if self.__try_connect(look_for_keys=False, pkey=key):
+					break
 
 		if not self.__connected:
 			self.__try_connect(password=password, look_for_keys=True, raise_error=True)

--- a/king_phisher/ssh_forward.py
+++ b/king_phisher/ssh_forward.py
@@ -158,6 +158,9 @@ class SSHTCPForwarder(threading.Thread):
 				if self.__try_connect(look_for_keys=False, pkey=key):
 					break
 
+		if not self.__connected and len(agent_keys) == 1:
+			self.__try_connect(look_for_keys=False, pkey=agent_keys[0])
+
 		if not self.__connected:
 			self.__try_connect(password=password, look_for_keys=True, raise_error=True)
 


### PR DESCRIPTION
# SSH Forwarding Update

## Description
There has been a recurring problem with users running into issues setting their
preferred ssh-key in the server_configuration. Spencer brought up the idea of having
king-phisher attempt to authenticate with all possible keys so users would no longer
have to specify their preferred ssh-key mitigating this recurring problem. This update will attempt to authenticate will all available ssh-keys. 

## Test-Cases
- [ ] Successfully authenticate to king-phisher without specifying a preferred-ssh-key. 