### PR TITLE
SSH Forwarding Update

### DIFF
--- a/king_phisher/ssh_forward.py
+++ b/king_phisher/ssh_forward.py
@@ -153,8 +153,10 @@ class SSHTCPForwarder(threading.Thread):
 			else:
 				self.logger.warning('failed to identify the user specified key for ssh authentication')
 
-		if not self.__connected and len(agent_keys) == 1:
-			self.__try_connect(look_for_keys=False, pkey=agent_keys[0])
+		if not self.__connected and agent_keys:
+			for key in agent_keys:
+				if self.__try_connect(look_for_keys=False, pkey=key):
+					break
 
 		if not self.__connected:
 			self.__try_connect(password=password, look_for_keys=True, raise_error=True)


### PR DESCRIPTION
# SSH Forwarding Update

## Description
There has been a recurring problem with users running into issues setting their
preferred ssh-key in the client configuration. Spencer brought up the idea of having
king-phisher attempt to authenticate with all possible keys so users would no longer
have to specify their preferred ssh-key mitigating this recurring problem. This update will attempt to authenticate will all available ssh-keys. 

## Test-Cases
- [x] Successfully authenticate to king-phisher without specifying a preferred-ssh-key. 
- [ ] Correctly log all attempted key's while authenticating. 