### PR TITLE
Access Method

### DIFF
--- a/docs/source/king_phisher/server/fs_utilities.rst
+++ b/docs/source/king_phisher/server/fs_utilities.rst
@@ -10,4 +10,6 @@ the application.
 Functions
 ---------
 
+.. autofunction:: access
+
 .. autofunction:: chown


### PR DESCRIPTION
# Access Method

## Description
There seems to be a significant need for determining the permissions a user has
on files outside of the current user. Access acts as a wrapper for **os.access** by
extending the ability to specify a user and/or group along with a file to test permissions against.

## Requirements
- [x] Allow users to specify a file to test against
- [x] Allow users to specify a mode to test against (R_OK, W_OK, X_OK)
- [x] Enable user to specify either a user *or* a group to test against.
- [x] Successfully enumerate a users or groups permission on a specific filet.


## Run / test configuration
* **Run Config**
  * access(*test-file*, *mode*, user=*user*, group=*group*)
  * Either user or group must be specified only one can be left as default.
* **Owner Tests**
  * Make a user the owner: `chown <user> test-file`
    * Owner and read `chmod u+r test-file`
    * Owner and write `chmod u+w test-file`
    * Owner and execute `chmod u+x test-file`
* **User's Group Tests & All group Test**
  * Make a user's group the owner: `chown :<user's-group> test-file`
  * To test other groups other than the user's group, enumerate a group they're apart of <br> (e.g, adm) and add that group to the file: `chown :<enumerated-group> test-file`
    * Group and read `chmod g+r test-file`
    * Group and write `chmod g+w test-file`
    * Group and execute `chmod g+x test-file`
* **Other Tests**
  * Other and read `chmod o+r test-file`
  * Other and write `chmod o+w test-file`
  * Other and execute `chmod o+x test-file`
