### PR TITLE
Pipenv `--three`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 .python-version
 .venv
 .venv/*
+Pipfile.lock
 build/*
 configs/*
 dist/*

--- a/docs/source/change_log.rst
+++ b/docs/source/change_log.rst
@@ -15,8 +15,8 @@ Version 1.14.0
 
 * Added the ``Message-ID`` MIME header to outgoing messages
 * Attempt SSH authentication with all agent-provided SSH keys
-* Deleted `Pipefile.lock` from repository to prevent hash issues between python interpreter versions.
-* Add `--three` to `pipenv install` and `pipenv --update` startup procedures to force use of `python3`.
+* Deleted ``Pipefile.lock`` from repository to prevent hash issues between python interpreter versions
+* Add ``--three`` to ``pipenv install`` and ``pipenv --update`` startup procedures to force use of ``Python3``
 
 Version 1.13.1
 ^^^^^^^^^^^^^^

--- a/docs/source/change_log.rst
+++ b/docs/source/change_log.rst
@@ -15,6 +15,8 @@ Version 1.14.0
 
 * Added the ``Message-ID`` MIME header to outgoing messages
 * Attempt SSH authentication with all agent-provided SSH keys
+* Deleted `Pipefile.lock` from repository to prevent hash issues between python interpreter versions.
+* Add `--three` to `pipenv install` and `pipenv --update` startup procedures to force use of `python3`.
 
 Version 1.13.1
 ^^^^^^^^^^^^^^

--- a/king_phisher/startup.py
+++ b/king_phisher/startup.py
@@ -159,7 +159,7 @@ def pipenv_entry(parser, entry_point):
 			logger.info('installing the pipenv environment')
 		else:
 			logger.warning('no pre-existing pipenv environment was found, installing it now')
-		results = _run_pipenv(('--site-packages', 'install'), cwd=target_directory)
+		results = _run_pipenv(('--site-packages', '--three', 'install'), cwd=target_directory)
 		if results.status:
 			logger.error('failed to install the pipenv environment')
 			logger.info('removing the incomplete .venv directory')
@@ -173,7 +173,7 @@ def pipenv_entry(parser, entry_point):
 
 	if arguments.pipenv_update:
 		logger.info('updating the pipenv environment')
-		results = _run_pipenv(('--site-packages', 'update'), cwd=target_directory)
+		results = _run_pipenv(('--site-packages', '--three', 'update'), cwd=target_directory)
 		if results.status:
 			logger.error('failed to update the pipenv environment')
 			return results.status


### PR DESCRIPTION
This PR forces python3 to be used during the installation of the `pipenv`.
In addition updated change log to reflect the delectation of the `Pipefile.lock` file and added the file to `.gitignore` file.

Testing:
- [x] remove python3 `pipenv` installation and install `pipenv` with python2
- [x] `./KingPhisher --env-install` installs default python3 interpreter for the system.
- [x] `./KingPhisher --env-update` updates pip requirements and default python3 interpreter for the system.
