### PR TITLE
Server auto install plugin pip requirements

### DIFF
--- a/data/server/king_phisher/server_config.yml
+++ b/data/server/king_phisher/server_config.yml
@@ -107,6 +107,10 @@ server:
   #  some_plugin:
   #    # An option specific to this particular plugin
   #    value_for_some_plugin: true
+  # Plugin Library depenacy path
+  plugin_library_path: /var/king-phisher/libs/plugin_site_packages
+  # Auto install server plugin requirements
+  plugin_install_requirements: True
 
   # Require an ID associated with a campaign to load pages
   require_id: true

--- a/data/server/king_phisher/server_config.yml
+++ b/data/server/king_phisher/server_config.yml
@@ -101,16 +101,16 @@ server:
   # Add additional search paths for plugin directories
   #plugin_directories:
   #  - /some/plugin/path
+  # Auto install server plugin python requirements
+  plugin_install_requirements: True
+  # Plugin library dependency path
+  plugin_library_path: /var/king-phisher/libs/plugin_site_packages
   # List the plugins that need to be enabled
   #plugins:
   #  # The plugin to enable's name
   #  some_plugin:
   #    # An option specific to this particular plugin
   #    value_for_some_plugin: true
-  # Plugin Library depenacy path
-  plugin_library_path: /var/king-phisher/libs/plugin_site_packages
-  # Auto install server plugin requirements
-  plugin_install_requirements: True
 
   # Require an ID associated with a campaign to load pages
   require_id: true

--- a/docs/source/change_log.rst
+++ b/docs/source/change_log.rst
@@ -17,6 +17,7 @@ Version 1.14.0
 * Attempt SSH authentication with all agent-provided SSH keys
 * Deleted ``Pipefile.lock`` from repository to prevent hash issues between python interpreter versions
 * Add ``--three`` to ``pipenv install`` and ``pipenv --update`` startup procedures to force use of ``Python3``
+* Server will now attempt to install missing plugin python packages during initialization.
 
 Version 1.13.1
 ^^^^^^^^^^^^^^

--- a/king_phisher/client/windows/plugin_manager.py
+++ b/king_phisher/client/windows/plugin_manager.py
@@ -391,7 +391,15 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 				self._update_status_bar_tsafe(
 					"Installing {:,} dependenc{} for plugin {} from PyPi.".format(len(packages), 'y' if len(packages) == 1 else 'ies', named_row.title)
 				)
-				pip_results = self.application.plugin_manager.install_packages(packages)
+				if self.application.plugin_manager.library_path:
+					pip_results = self.application.plugin_manager.install_packages(packages)
+				else:
+					self.logger.warning('no library path to install plugin dependencies')
+					_show_dialog_error_tsafe(
+						"Failed to run pip to install package(s) for plugin {}.".format(named_row.id)
+					)
+					# set pip results to none to safely complete and cleanly release installing lock.
+					pip_results = None
 				if pip_results is None:
 					self.logger.warning('pip install failed')
 					_show_dialog_error_tsafe(

--- a/king_phisher/client/windows/plugin_manager.py
+++ b/king_phisher/client/windows/plugin_manager.py
@@ -322,15 +322,6 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 		# WARNING: this may not be called from the GUI thread
 		self.__load_errors[name] = (error, traceback.format_exception(*sys.exc_info(), limit=5))
 
-	def _pip_install(self, packages):
-		options = ['--no-color']
-		if self.application.user_library_path is None:
-			self.logger.warning('can not install packages with out a defined library path')
-			return
-		options.extend(['--target', self.application.user_library_path])
-		args = [sys.executable, '-m', 'pip', 'install'] + options + packages
-		return startup.run_process(args)
-
 	def _plugin_disable(self, model_row):
 		named_row = _ModelNamedRow(*model_row)
 		self.application.plugin_manager.disable(named_row.id)
@@ -400,7 +391,7 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 				self._update_status_bar_tsafe(
 					"Installing {:,} dependenc{} for plugin {} from PyPi.".format(len(packages), 'y' if len(packages) == 1 else 'ies', named_row.title)
 				)
-				pip_results = self._pip_install(packages)
+				pip_results = self.application.plugin_manager.install_packages(packages)
 				if pip_results is None:
 					self.logger.warning('pip install failed')
 					_show_dialog_error_tsafe(

--- a/king_phisher/plugins.py
+++ b/king_phisher/plugins.py
@@ -611,6 +611,16 @@ class PluginManagerBase(object):
 		return module
 
 	def install_packages(self, packages):
+		"""
+		This function will take a list of python packages and attempt to install
+		them through pip to target path.
+
+		.. versionadded:: 1.14.0
+
+		:param list packages: list of python packages to install using pip.
+		:return: The process results from the command execution.
+		:type: :py:class:`~.ProcessResults`
+		"""
 		options = []
 		if self.library_path is None:
 			raise errors.KingPhisherResourceError("missing library path")


### PR DESCRIPTION
# Server auto install pip requirements for plugins
This PR addresses `pipenv` removing python packages manually being installed that are not in the `Pipefile`. 

This PR adds two new option into the server config. First is the `server.plugin_library_path` where the user can define where they want plugin libraries to install. This value is defaulted to: `/var/king-phisher/libs/plugin_site_packages`. The second value is `server.plugin_install_requirements` where the user can specify if King Phisher Server should automatically try to install missing package dependencies of it's plugins. This value defaults to `True`.

## Testing
Set your testing environment to use a plugin that requires a dependency that is not included in the King Phisher Environment.
- [x] Set`server.plugin_install_requirements` option to false. Start server and it does not install package and fails out for not having the package installed.
- [x] Set`server.plugin_install_requirements` to True. Start Server and verify it auto installs python package into path defined by server config.
- [x] Profit?