### PR TITLE
Windows updates for plugin pypi packages installation

### DIFF
--- a/king_phisher/catalog.py
+++ b/king_phisher/catalog.py
@@ -248,6 +248,7 @@ class Repository(object):
 			collection.freeze()
 			self.collections[collection_type] = Collection(self, collection_type, collection)
 		self.collections.freeze()
+		self.logger.debug("completed init Repository ")
 
 	def __repr__(self):
 		return "<{0} title={1!r} >".format(self.__class__.__name__, self.title)

--- a/king_phisher/client/windows/plugin_manager.py
+++ b/king_phisher/client/windows/plugin_manager.py
@@ -866,7 +866,7 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 			return
 		if plugin_id in self.application.plugin_manager:
 			klass = self.application.plugin_manager[plugin_id]
-			compatibility_details = klass.compatibility
+			compatibility_details = list(klass.compatibility)
 		else:
 			repo_model, catalog_model = self._get_plugin_model_parents(self._last_plugin_selected)
 			compatibility_details = list(self.catalog_plugins.compatibility(catalog_model.id, repo_model.id, named_plugin.id))
@@ -884,7 +884,6 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 		row = 0
 		for row, req in enumerate(compatibility_details):
 			grid.insert_row(row)
-			self.logger.debug(req)
 			if row == 0:
 				label = Gtk.Label(req[0])
 			else:

--- a/king_phisher/client/windows/plugin_manager.py
+++ b/king_phisher/client/windows/plugin_manager.py
@@ -313,7 +313,10 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 					sensitive_installed=self._is_sensitive_installed(self.catalog_plugins.compatibility(catalog.id, repo.id, plugin_name), plugin_name),
 					type=_ROW_TYPE_PLUGIN
 				))
-		gui_utilities.glib_idle_add_once(self.__store_add_node, catalog_node)
+		self.logger.debug("adding catalog to tree view")
+		gui_utilities.glib_idle_add_wait(self._store_add_node, catalog_node)
+		self.logger.debug("completed adding catalog to tree view")
+		#gui_utilities.glib_idle_add_once(self.__store_add_node, catalog_node)
 
 	def _is_sensitive_installed(self, compatibility_details, plugin_name):
 		log_line = "plugin {} has insensitive install due to {}"
@@ -735,7 +738,7 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 			if not self._installed_plugins_treeview_tracker[plugin]:
 				self._installed_plugins_treeview_tracker.pop(plugin)
 		if refresh:
-			gui_utilities.glib_idle_add_once(self._model.clear)
+			gui_utilities.glib_idle_add_wait(self._model.clear)
 		expiration = datetime.timedelta(seconds=smoke_zephyr.utilities.parse_timespan(self.config.get('cache.age', '4h')))
 		self._update_status_bar_tsafe('Loading, catalogs...')
 		self._load_catalog_local_tsafe()
@@ -787,6 +790,7 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 			self.logger.warning("{0} error when trying to add catalog dict to manager".format(error.__class__.__name))
 		else:
 			self.catalog_plugins.add_catalog(catalog, catalog_url=catalog_cache_dict['url'], cache=False)
+			self.logger.debug("calling add catalog to tree tsafe")
 			self._add_catalog_to_tree_tsafe(catalog)
 		self.logger.debug('completed loading catalog cache')
 		return catalog

--- a/king_phisher/client/windows/plugin_manager.py
+++ b/king_phisher/client/windows/plugin_manager.py
@@ -740,10 +740,12 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 		self._update_status_bar_tsafe('Loading, catalogs...')
 		self._load_catalog_local_tsafe()
 		catalog_cache = self.catalog_plugins.get_cache()
+		self.logger.debug('checking plugin cache')
 		now = datetime.datetime.utcnow()
 		for catalog_url in self.config['catalogs']:
 			catalog_cache_dict = catalog_cache.get_catalog_by_url(catalog_url)
 			if not refresh and catalog_cache_dict and catalog_cache_dict['created'] + expiration > now:
+				self.logger.debug("loading catalog from cache")
 				catalog = self._load_catalog_from_cache_tsafe(catalog_cache_dict)
 				if catalog is not None:
 					continue
@@ -755,7 +757,9 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 				self.logger.warning('failing over to loading the catalog from the cache')
 				self._load_catalog_from_cache_tsafe(catalog_cache_dict)
 		if self._installed_plugins_treeview_tracker:
+			self.logger.debug("calling load missing plugins")
 			self._load_missing_plugins_tsafe()
+		self.logger.debug("Loading Catalogs Complete")
 		self._update_status_bar_tsafe('Loading completed')
 		self._installed_plugins_treeview_tracker = None
 
@@ -768,9 +772,11 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 		for model_row in self._model:
 			if _ModelNamedRow(*model_row).id == _LOCAL_REPOSITORY_ID:
 				gui_utilities.glib_idle_add_wait(self._model.remove, model_row.iter)
+				self.logger.debug('breaking')
 				break
 		else:
 			raise RuntimeError('failed to find the local plugin repository')
+		self.logger.debug("calling load catalog local from missing plugins")
 		self._load_catalog_local_tsafe()
 
 	def _load_catalog_from_cache_tsafe(self, catalog_cache_dict):
@@ -782,6 +788,7 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 		else:
 			self.catalog_plugins.add_catalog(catalog, catalog_url=catalog_cache_dict['url'], cache=False)
 			self._add_catalog_to_tree_tsafe(catalog)
+		self.logger.debug('completed loading catalog cache')
 		return catalog
 
 	def _load_catalog_from_url_tsafe(self, catalog_url):
@@ -797,6 +804,7 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 		else:
 			self.catalog_plugins.add_catalog(catalog, catalog_url=catalog_url, cache=True)
 			self._add_catalog_to_tree_tsafe(catalog)
+		self.logger.debug('completed downloading catalog')
 		return catalog
 
 	def _load_catalog_local_tsafe(self):
@@ -850,7 +858,9 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 				sensitive_installed=False,
 				type=_ROW_TYPE_PLUGIN
 			))
+		self.logger.debug('idle add for nods being called')
 		gui_utilities.glib_idle_add_wait(self.__store_add_node, node)
+		self.logger.debug('completed idle add')
 
 	#
 	# Signal Handlers

--- a/king_phisher/plugins.py
+++ b/king_phisher/plugins.py
@@ -627,7 +627,11 @@ class PluginManagerBase(object):
 		if self.library_path is None:
 			raise errors.KingPhisherResourceError('missing plugin-specific library path')
 		options.extend(['--target', self.library_path])
-		args = [sys.executable, '-m', 'pip', 'install'] + options + packages
+		if its.frozen:
+			executable_path = os.path.dirname(sys.executable)
+			args = [os.path.join(executable_path, 'python.exe'), '-m', 'pip', 'install'] + options + packages
+		else:
+			args = [sys.executable, '-m', 'pip', 'install'] + options + packages
 		if len(packages) > 1:
 			info_string = "installing packages: {}"
 		else:

--- a/king_phisher/plugins.py
+++ b/king_phisher/plugins.py
@@ -139,10 +139,10 @@ class OptionString(OptionBase):
 Requirement = collections.namedtuple('Requirement', ('type', 'value', 'comptabile'))
 
 _RequirementMeta = collections.namedtuple('RequirementMeta', ('name', 'title'))
-class _RequirementType(enum.Enum):
+class RequirementType(enum.Enum):
 	PACKAGE = _RequirementMeta(name='package', title='Required Package')
 	PYTHON_VERSION = _RequirementMeta('minimum-python-version', 'Minimum Python Version')
-	VERSION = _RequirementMeta('minimum-kp-version', 'Minimum King Phisher Version')
+	VERSION = _RequirementMeta('minimum-version', 'Minimum King Phisher Version')
 	PLATFORMS = _RequirementMeta('platforms', 'Supported Platforms')
 
 class Requirements(collections.abc.Mapping):
@@ -199,20 +199,20 @@ class Requirements(collections.abc.Mapping):
 		if self._storage.get('minimum-python-version'):
 			# platform.python_version() cannot be used with StrictVersion because it returns letters in the version number.
 			available = StrictVersion(self._storage['minimum-python-version']) <= StrictVersion('.'.join(map(str, sys.version_info[:3])))
-			yield Requirement(_RequirementType.PYTHON_VERSION, self._storage['minimum-python-version'], available)
+			yield Requirement(RequirementType.PYTHON_VERSION, self._storage['minimum-python-version'], available)
 
 		if self._storage.get('minimum-version'):
 			available = StrictVersion(self._storage['minimum-version']) <= StrictVersion(version.distutils_version)
-			yield Requirement(_RequirementType.VERSION, self._storage['minimum-version'], available)
+			yield Requirement(RequirementType.VERSION, self._storage['minimum-version'], available)
 
 		if self._storage.get('packages'):
 			for name, available in self._storage['packages'].items():
-				yield Requirement(_RequirementType.PACKAGE, name, available)
+				yield Requirement(RequirementType.PACKAGE, name, available)
 
 		if self._storage.get('platforms'):
 			platforms = tuple(p.title() for p in self._storage['platforms'])
 			system = platform.system()
-			yield Requirement(_RequirementType.PLATFORMS, ', '.join(platforms), system.title() in platforms)
+			yield Requirement(RequirementType.PLATFORMS, ', '.join(platforms), system.title() in platforms)
 
 	def _check_for_missing_packages(self, packages):
 		missing_packages = []

--- a/tools/development/cx_freeze.py
+++ b/tools/development/cx_freeze.py
@@ -30,6 +30,7 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+import collections
 import os
 import site
 import sys
@@ -133,6 +134,12 @@ include_files.append(('data/client/king_phisher', 'king_phisher'))
 include_files.append(('data/king_phisher', 'king_phisher'))
 include_files.append((pytz.__path__[0], 'pytz'))
 include_files.append((requests.__path__[0], 'requests'))
+include_files.append((collections.__path__[0], 'collections'))
+
+# include pip executible
+executable_path = os.path.dirname(sys.executable)
+include_files.append((os.path.join(executable_path, 'Scripts'), 'Scripts'))
+include_files.append((os.path.join(executable_path, 'python.exe'), 'python.exe'))
 
 exe_base = 'Win32GUI'
 if is_debugging_build:
@@ -157,6 +164,7 @@ build_exe_options = dict(
 		'cffi',
 		'collections',
 		'cryptography',
+		'distutils',
 		'dns',
 		'email',
 		'email_validator',
@@ -177,6 +185,10 @@ build_exe_options = dict(
 		'numpy',
 		'paramiko',
 		'pil',
+		'pip',
+		'os',
+		'six',
+		'sys',
 		'pkg_resources',
 		'pluginbase',
 		'qrcode',


### PR DESCRIPTION
This PR adds in the python.exe and pip.exe to the Windows build to allow the frozen windows application to install python packages from pypi during plugin installation. Also added in `disutils`, `six`, `os`, `sys`, to allow pip to build packages. 

Added in logic to prevent installation of packages that are not supported on the operating system.
