### PR TITLE
Added Numpy Pipfile requirement + version ref reason

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -44,6 +44,7 @@ MarkupSafe = "==1.1.1"
 PyYAML = "==5.1.2"
 SQLAlchemy = "==1.3.8"
 XlsxWriter = "==1.2.1"
+numpy = "==1.16.4" 
 basemap = {file = "https://github.com/matplotlib/basemap/archive/v1.2.1rel.tar.gz"}
 pyproj = "==2.4.0"
 rule-engine = "~=1.1"

--- a/docs/source/development/versions_reference.rst
+++ b/docs/source/development/versions_reference.rst
@@ -8,7 +8,7 @@ regarding dropping support for legacy systems.
 Python Packages Reference Table
 -------------------------------
 
-**Last Updated:** August 21\ :sup:`st`, 2019 by Erik Daguerre
+**Last Updated:** November 21\ :sup:`st`, 2019 by Mike Stringer
 
 +-----------------------------+-------------------------+----------------+
 | Package                     | Reason                  | Pinned Version |
@@ -20,6 +20,9 @@ Python Packages Reference Table
 +-----------------------------+-------------------------+----------------+
 | grapohql-relay              | Highest version for     | 2.1.1          |
 |                             | graphene-sqlalchemy     |                |
++-----------------------------+-------------------------+----------------+
+| numpy                       | Required by basemap but | 1.16.4         |
+|                             | not preinstalled by pip |                |
 +-----------------------------+-------------------------+----------------+
 | matplotlib                  | Windows Build           | 2.2.4          |
 |                             | Limitation              |                |


### PR DESCRIPTION
Discovered a rare bug when numpy is missing from the native environment due to basemap failing to check whether numpy is installed prior to importing it in its setup.py file. 

The current workaround is to require numpy before matplotlib and basemap are installed so as to guarantee it will succeed in all cases.

This resolves issue #415 